### PR TITLE
feat: add byzantine cometbft message tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ cd Byzantine-simulate
 go mod tidy
 ```
 
-### 3. Run the CometBFT demo
+### 3. Explore the CometBFT demo CLI
 ```bash
 go run cmd/demo/main.go
 ```
-- Streams real CometBFT proposal, prevote, and precommit messages through the `CanonicalMessage` transformer.
-- Demonstrates round-trip conversion (`original → canonical → original`) using artifacts such as `examples/cometbft/Vote.json`.
+- Lists the available scenarios (`simulation`, `vote-batch`, `byzantine`).
+- `-scenario=simulation` streams synthetic CometBFT messages through the canonical mapper.
+- `-scenario=vote-batch` replays fixtures from `examples/cometbft/Vote.json` and validates the round-trip.
+- `-scenario=byzantine` forges double votes or proposals from a canonical payload using the byzantine mapper.
 
 ### 4. Execute tests
 ```bash

--- a/cmd/byzantine/main.go
+++ b/cmd/byzantine/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/message/abstraction"
+)
+
+type outputMessage struct {
+	ChainType   abstraction.ChainType  `json:"chain_type"`
+	ChainID     string                 `json:"chain_id"`
+	MessageType string                 `json:"message_type"`
+	Encoding    string                 `json:"encoding"`
+	Timestamp   string                 `json:"timestamp"`
+	Payload     json.RawMessage        `json:"payload"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+}
+
+func main() {
+	inputPath := flag.String("input", "", "Path to a canonical message JSON file")
+	actionFlag := flag.String("action", string(cometbftAdapter.ByzantineActionDoubleVote), "Byzantine action to apply (double-vote|double-proposal|none)")
+	chainID := flag.String("chain-id", "cosmos-hub-4", "Chain identifier used when re-encoding the message")
+	alternateBlock := flag.String("alternate-block", "", "Alternate block hash to use for the forged message")
+	alternatePrev := flag.String("alternate-prev-hash", "", "Alternate previous block hash (used for proposals)")
+	alternateSig := flag.String("alternate-signature", "", "Alternate signature to attach to the forged message")
+	outputPath := flag.String("output", "", "Optional path to write the resulting CometBFT messages as JSON")
+	flag.Parse()
+
+	if strings.TrimSpace(*inputPath) == "" {
+		fmt.Fprintln(os.Stderr, "input path is required")
+		os.Exit(1)
+	}
+
+	canonical, err := loadCanonical(*inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load canonical message: %v\n", err)
+		os.Exit(1)
+	}
+
+	mapper := cometbftAdapter.NewCometBFTMapper(*chainID)
+
+	action, err := cometbftAdapter.ParseByzantineAction(*actionFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid byzantine action: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := cometbftAdapter.ByzantineOptions{
+		AlternateBlockHash: *alternateBlock,
+		AlternatePrevHash:  *alternatePrev,
+		AlternateSignature: *alternateSig,
+	}
+
+	rawMessages, err := mapper.FromCanonicalByzantine(canonical, action, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "conversion failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	outputs := make([]outputMessage, len(rawMessages))
+	for i, raw := range rawMessages {
+		outputs[i] = outputMessage{
+			ChainType:   raw.ChainType,
+			ChainID:     raw.ChainID,
+			MessageType: raw.MessageType,
+			Encoding:    raw.Encoding,
+			Timestamp:   raw.Timestamp.Format(time.RFC3339Nano),
+			Payload:     json.RawMessage(raw.Payload),
+			Metadata:    raw.Metadata,
+		}
+	}
+
+	result, err := json.MarshalIndent(outputs, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode output: %v\n", err)
+		os.Exit(1)
+	}
+
+	if strings.TrimSpace(*outputPath) != "" {
+		if err := os.WriteFile(*outputPath, result, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write output file: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Generated %d messages with action %s and wrote them to %s\n", len(outputs), action, *outputPath)
+		return
+	}
+
+	fmt.Println(string(result))
+}
+
+func loadCanonical(path string) (*abstraction.CanonicalMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var canonical abstraction.CanonicalMessage
+	if err := json.Unmarshal(data, &canonical); err != nil {
+		return nil, err
+	}
+	if canonical.Timestamp.IsZero() {
+		canonical.Timestamp = time.Now().UTC()
+	}
+	return &canonical, nil
+}

--- a/cmd/demo/README.md
+++ b/cmd/demo/README.md
@@ -1,92 +1,63 @@
-# CometBFT Demo
+# CometBFT Demo CLI
 
-CometBFT Byzantine Message Bridge 데모 프로그램입니다.
+This CLI showcases how the PBFT canonical mapper powers different kinds of CometBFT experiments. It exposes three scenarios:
 
-## 실행 방법
+1. **simulation** – Streams randomly generated CometBFT messages through the canonical mapper so you can inspect the round-trip flow.
+2. **vote-batch** – Replays fixtures from `examples/cometbft/Vote.json` and verifies that they survive a canonical round-trip.
+3. **byzantine** – Loads a canonical message (either from a file or derived from the fixtures) and emits forged CometBFT payloads using the byzantine pipeline.
+
+## Usage
 
 ```bash
-# 프로젝트 루트에서 실행
+# Show the available scenarios
 go run cmd/demo/main.go
+
+# Run the live simulator for 15 seconds
+go run cmd/demo/main.go -scenario=simulation -duration=15s
+
+# Replay and verify the bundled vote fixtures
+go run cmd/demo/main.go -scenario=vote-batch
+
+# Forge double proposals derived from the fixtures
+go run cmd/demo/main.go -scenario=byzantine -action=double-proposal
 ```
 
-## 기능
+You can provide your own canonical input for the byzantine scenario using `-canonical=/path/to/canonical.json`. Optional flags `-alternate-block`, `-alternate-prev`, and `-alternate-signature` override the forged fields when you need explicit values.
 
-1. **메시지 시뮬레이션**: CometBFT 합의 메시지를 실시간으로 생성하고 변환
-2. **Vote 변환 테스트**: Vote.json 파일의 예제들을 사용한 변환 테스트
-3. **설정 테스트**: 기본 타입들이 정상적으로 로드되는지 확인
-
-## 파일 구조
-
-- `main.go`: 통합된 CometBFT 데모 프로그램
-
-## 예제 파일
-
-`examples/cometbft/Vote.json` 파일이 있어야 Vote 변환 테스트가 정상 작동합니다.
-
-## 출력 예시
+## Output snapshot
 
 ```
-🎮 CometBFT Byzantine Message Bridge 데모
-=======================================
+PBFT Message Abstraction Demo
+============================
 
-📋 사용 가능한 데모:
-   1. 메시지 시뮬레이션
-   2. Vote 변환 테스트
-   3. WAL 파일 분석
-   4. 로컬넷 설정
-   5. 설정 테스트
+Scenarios:
+  - simulation: Stream randomly generated CometBFT messages through the canonical mapper.
+  - vote-batch: Replay vote samples from examples/cometbft/Vote.json and verify round-trips.
+  - byzantine:  Emit forged CometBFT payloads from a canonical message using the byzantine pipeline.
 
-🚀 CometBFT 메시지 시뮬레이션 시작...
+Example usage:
+  go run cmd/demo/main.go -scenario=simulation -duration=15s
+  go run cmd/demo/main.go -scenario=vote-batch
+  go run cmd/demo/main.go -scenario=byzantine -action=double-proposal
 
-🚀 CometBFT 실시간 메시지 시뮬레이션 시작
-=====================================
-⏱️  실행 시간: 10s
+🧪 CometBFT Vote Round-Trip
+===========================
+Loaded vote fixtures from examples/cometbft/Vote.json
 
-📨 메시지 #1: CometBFT proposal 메시지 생성
-   🔄 Canonical: height=1000, type=proposal
-   📤 변환 완료: proposal
-
-📨 메시지 #2: CometBFT prevote 메시지 생성
-   🔄 Canonical: height=1001, type=prevote
-   📤 변환 완료: prevote
-
-...
-
-✅ 시뮬레이션 완료! 총 5개 메시지 처리
-
-🧪 Vote 변환 테스트 실행...
-🧪 Vote 변환 테스트
-==================
-✅ Vote.json 파일 읽기 완료
-
-📦 테스트 1: Prevote for Block
-----------------------------------------
-   🔄 RawCometBFT → Canonical 변환 중...
-   🔄 Canonical → RawCometBFT 변환 중...
-   🔍 원본과 변환된 메시지 비교 중...
-   📊 변환 요약:
+Case 1 → Prevote for Block
+-----------
+   Fixture → Raw consensus message
+   Raw → Canonical
+   Canonical → Raw
+   Comparing original and converted payloads
+   Summary
       Type: prevote
-      Height: 1000
-      Round: 1
-      BlockHash: 0x1234567890abcdef...
-      Validator: validator1
-      Extensions: 0개
-✅ 변환 성공!
+      Height: 882281
+      Round: 0
+      Block hash: 6D895…
+      Validator: cosmosvalcons1...
+      Extension count: 0
+Result: success
 
-...
-
-📊 전체 결과: 6/6 성공 (100.0%)
-🎉 모든 Vote 변환 테스트 통과!
-
-🔧 설정 테스트 실행...
-🔧 Byzantine Message Bridge 설정 테스트
-=====================================
-✅ ChainTypeCometBFT: cometbft
-✅ ChainTypeHyperledger: hyperledger
-✅ ChainTypeKaia: kaia
-✅ MsgTypeProposal: proposal
-✅ MsgTypeVote: vote
-✅ MsgTypeBlock: block
-
-🎉 모든 기본 타입이 정상적으로 로드되었습니다!
+Summary: 6/6 cases succeeded (100.0%).
 ```

--- a/cmd/demo/byzantine.go
+++ b/cmd/demo/byzantine.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/message/abstraction"
+)
+
+func runByzantineScenario(mapper *cometbftAdapter.CometBFTMapper, actionFlag, canonicalPath, alternateBlock, alternatePrev, alternateSig string) {
+	fmt.Println("🧨 Byzantine Message Emission")
+	fmt.Println("============================")
+
+	action, err := cometbftAdapter.ParseByzantineAction(actionFlag)
+	if err != nil {
+		fmt.Printf("invalid byzantine action %q: %v\n", actionFlag, err)
+		return
+	}
+
+	canonical, sourceDescription, err := loadCanonicalForScenario(mapper, canonicalPath)
+	if err != nil {
+		fmt.Printf("failed to prepare canonical message: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Using canonical message from %s\n", sourceDescription)
+	printCanonicalMessage(canonical)
+
+	opts := cometbftAdapter.ByzantineOptions{
+		AlternateBlockHash: alternateBlock,
+		AlternatePrevHash:  alternatePrev,
+		AlternateSignature: alternateSig,
+	}
+
+	rawMessages, err := mapper.FromCanonicalByzantine(canonical, action, opts)
+	if err != nil {
+		fmt.Printf("byzantine conversion failed: %v\n", err)
+		return
+	}
+
+	for i, raw := range rawMessages {
+		fmt.Printf("\nForged message #%d (%s)\n", i+1, strings.ToUpper(raw.MessageType))
+		printRawMessage(*raw)
+	}
+
+	fmt.Printf("\nGenerated %d CometBFT messages via action %s.\n", len(rawMessages), action)
+}
+
+func loadCanonicalForScenario(mapper *cometbftAdapter.CometBFTMapper, canonicalPath string) (*abstraction.CanonicalMessage, string, error) {
+	if strings.TrimSpace(canonicalPath) != "" {
+		canonical, err := readCanonicalFromFile(canonicalPath)
+		if err != nil {
+			return nil, "file://" + canonicalPath, err
+		}
+		if canonical.Timestamp.IsZero() {
+			canonical.Timestamp = time.Now().UTC()
+		}
+		return canonical, "file://" + canonicalPath, nil
+	}
+
+	voteData, err := readVoteJSON()
+	if err != nil {
+		return nil, "examples/cometbft/Vote.json", err
+	}
+
+	rawVote, err := createRawVoteFromFixtures(voteData, "prevote_for_block")
+	if err != nil {
+		return nil, "examples/cometbft/Vote.json:prevote_for_block", err
+	}
+
+	canonical, err := mapper.ToCanonical(rawVote)
+	if err != nil {
+		return nil, "examples/cometbft/Vote.json:prevote_for_block", err
+	}
+	return canonical, "examples/cometbft/Vote.json:prevote_for_block", nil
+}
+
+func readCanonicalFromFile(path string) (*abstraction.CanonicalMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var canonical abstraction.CanonicalMessage
+	if err := json.Unmarshal(data, &canonical); err != nil {
+		return nil, err
+	}
+	return &canonical, nil
+}

--- a/cmd/demo/utils.go
+++ b/cmd/demo/utils.go
@@ -7,46 +7,23 @@ import (
 	"codec/message/abstraction"
 )
 
-// printRawMessage prints a RawConsensusMessage in JSON format
 func printRawMessage(raw abstraction.RawConsensusMessage) {
-	fmt.Printf("      RawCometBFT Message:\n")
-
-	// JSON으로 예쁘게 출력
-	jsonData, err := json.MarshalIndent(raw, "         ", "  ")
-	if err != nil {
-		fmt.Printf("         Error marshaling: %v\n", err)
-		return
-	}
-	fmt.Printf("%s\n", string(jsonData))
+	fmt.Println("   Raw message")
+	prettyPrintJSON(raw)
 }
 
-// printCanonicalMessage prints a CanonicalMessage in JSON format
 func printCanonicalMessage(canonical *abstraction.CanonicalMessage) {
-	fmt.Printf("      Canonical Message:\n")
+	fmt.Println("   Canonical message")
+	prettyPrintJSON(canonical)
+}
 
-	// JSON으로 예쁘게 출력
-	jsonData, err := json.MarshalIndent(canonical, "         ", "  ")
+func prettyPrintJSON(data interface{}) {
+	jsonData, err := json.MarshalIndent(data, "      ", "  ")
 	if err != nil {
-		fmt.Printf("         Error marshaling: %v\n", err)
+		fmt.Printf("      error marshaling JSON: %v\n", err)
 		return
 	}
 	fmt.Printf("%s\n", string(jsonData))
-}
-
-func RunSetupTest() {
-	fmt.Println("🔧 Byzantine Message Bridge 설정 테스트")
-	fmt.Println("=====================================")
-
-	// 기본 타입 테스트
-	fmt.Println("✅ ChainTypeCometBFT:", abstraction.ChainTypeCometBFT)
-	fmt.Println("✅ ChainTypeHyperledger:", abstraction.ChainTypeHyperledger)
-	fmt.Println("✅ ChainTypeKaia:", abstraction.ChainTypeKaia)
-
-	fmt.Println("✅ MsgTypeProposal:", abstraction.MsgTypeProposal)
-	fmt.Println("✅ MsgTypeVote:", abstraction.MsgTypeVote)
-	fmt.Println("✅ MsgTypeBlock:", abstraction.MsgTypeBlock)
-
-	fmt.Println("\n🎉 모든 기본 타입이 정상적으로 로드되었습니다!")
 }
 
 func min(a, b int) int {

--- a/cometbft/adapter/byzantine.go
+++ b/cometbft/adapter/byzantine.go
@@ -1,0 +1,191 @@
+package adapter
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"codec/message/abstraction"
+)
+
+// ByzantineAction describes the manipulation to apply when converting back to a CometBFT message.
+type ByzantineAction string
+
+const (
+	// ByzantineActionNone returns the canonical message without any manipulation.
+	ByzantineActionNone ByzantineAction = "none"
+	// ByzantineActionDoubleVote emits two vote messages with conflicting block hashes.
+	ByzantineActionDoubleVote ByzantineAction = "double_vote"
+	// ByzantineActionDoubleProposal emits two proposal messages that reference different blocks.
+	ByzantineActionDoubleProposal ByzantineAction = "double_proposal"
+)
+
+// ByzantineOptions contains optional overrides for the mutated messages.
+type ByzantineOptions struct {
+	AlternateBlockHash string
+	AlternatePrevHash  string
+	AlternateSignature string
+}
+
+// ParseByzantineAction converts a CLI string to the typed action.
+func ParseByzantineAction(value string) (ByzantineAction, error) {
+	switch strings.ToLower(value) {
+	case "", string(ByzantineActionNone):
+		return ByzantineActionNone, nil
+	case string(ByzantineActionDoubleVote):
+		return ByzantineActionDoubleVote, nil
+	case string(ByzantineActionDoubleProposal):
+		return ByzantineActionDoubleProposal, nil
+	default:
+		return ByzantineActionNone, fmt.Errorf("unknown byzantine action: %s", value)
+	}
+}
+
+// FromCanonicalByzantine converts a canonical message back to CometBFT format while applying a byzantine action.
+func (m *CometBFTMapper) FromCanonicalByzantine(msg *abstraction.CanonicalMessage, action ByzantineAction, opts ByzantineOptions) ([]*abstraction.RawConsensusMessage, error) {
+	switch action {
+	case ByzantineActionNone:
+		raw, err := m.rawFromCanonicalMessage(msg)
+		if err != nil {
+			return nil, err
+		}
+		return []*abstraction.RawConsensusMessage{raw}, nil
+	case ByzantineActionDoubleVote:
+		return m.doubleVoteMessages(msg, opts)
+	case ByzantineActionDoubleProposal:
+		return m.doubleProposalMessages(msg, opts)
+	default:
+		return nil, fmt.Errorf("unsupported byzantine action: %s", action)
+	}
+}
+
+func (m *CometBFTMapper) doubleVoteMessages(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.RawConsensusMessage, error) {
+	if msg.Type != abstraction.MsgTypePrevote && msg.Type != abstraction.MsgTypePrecommit && msg.Type != abstraction.MsgTypeVote {
+		return nil, fmt.Errorf("double_vote action requires a vote canonical message")
+	}
+
+	baseRaw, err := m.rawFromCanonicalMessage(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	mutated := cloneCanonicalMessage(msg)
+	mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
+	if opts.AlternateSignature != "" {
+		mutated.Signature = opts.AlternateSignature
+	}
+	if mutated.Timestamp.Equal(msg.Timestamp) {
+		mutated.Timestamp = mutated.Timestamp.Add(1 * time.Millisecond)
+	}
+
+	mutatedRaw, err := m.rawFromCanonicalMessage(mutated)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*abstraction.RawConsensusMessage{baseRaw, mutatedRaw}, nil
+}
+
+func (m *CometBFTMapper) doubleProposalMessages(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.RawConsensusMessage, error) {
+	if msg.Type != abstraction.MsgTypeProposal {
+		return nil, fmt.Errorf("double_proposal action requires a proposal canonical message")
+	}
+
+	baseRaw, err := m.rawFromCanonicalMessage(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	mutated := cloneCanonicalMessage(msg)
+	mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
+	if opts.AlternatePrevHash != "" {
+		mutated.PrevHash = opts.AlternatePrevHash
+	} else if mutated.PrevHash == msg.PrevHash {
+		mutated.PrevHash = chooseAlternateHash(msg.PrevHash, "")
+	}
+	if opts.AlternateSignature != "" {
+		mutated.Signature = opts.AlternateSignature
+	}
+	if mutated.Timestamp.Equal(msg.Timestamp) {
+		mutated.Timestamp = mutated.Timestamp.Add(1 * time.Millisecond)
+	}
+
+	mutatedRaw, err := m.rawFromCanonicalMessage(mutated)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*abstraction.RawConsensusMessage{baseRaw, mutatedRaw}, nil
+}
+
+func chooseAlternateHash(original, provided string) string {
+	if provided != "" {
+		return provided
+	}
+	if original == "" {
+		return "0000000000000000000000000000000000000000000000000000000000000000"
+	}
+
+	runes := []rune(original)
+	for i := len(runes) - 1; i >= 0; i-- {
+		switch runes[i] {
+		case '0':
+			runes[i] = '1'
+			return string(runes)
+		case '1':
+			runes[i] = '0'
+			return string(runes)
+		case 'a', 'A':
+			runes[i] = 'b'
+			return string(runes)
+		case 'f', 'F':
+			runes[i] = 'e'
+			return string(runes)
+		}
+	}
+	return original + "0"
+}
+
+func cloneCanonicalMessage(msg *abstraction.CanonicalMessage) *abstraction.CanonicalMessage {
+	if msg == nil {
+		return nil
+	}
+	cloned := *msg
+	if msg.Height != nil {
+		cloned.Height = new(big.Int).Set(msg.Height)
+	}
+	if msg.Round != nil {
+		cloned.Round = new(big.Int).Set(msg.Round)
+	}
+	if msg.View != nil {
+		cloned.View = new(big.Int).Set(msg.View)
+	}
+	if msg.CommitSeals != nil {
+		cloned.CommitSeals = append([]string(nil), msg.CommitSeals...)
+	}
+	if msg.ViewChanges != nil {
+		cloned.ViewChanges = make([]abstraction.ViewChangeEntry, len(msg.ViewChanges))
+		for i, vc := range msg.ViewChanges {
+			entry := vc
+			if vc.View != nil {
+				entry.View = new(big.Int).Set(vc.View)
+			}
+			if vc.Height != nil {
+				entry.Height = new(big.Int).Set(vc.Height)
+			}
+			cloned.ViewChanges[i] = entry
+		}
+	}
+	if msg.Extensions != nil {
+		copied := make(map[string]interface{}, len(msg.Extensions))
+		for k, v := range msg.Extensions {
+			copied[k] = v
+		}
+		cloned.Extensions = copied
+	}
+	if msg.RawPayload != nil {
+		cloned.RawPayload = append([]byte(nil), msg.RawPayload...)
+	}
+	return &cloned
+}

--- a/cometbft/adapter/byzantine_test.go
+++ b/cometbft/adapter/byzantine_test.go
@@ -1,0 +1,125 @@
+package adapter
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+
+	"codec/message/abstraction"
+)
+
+func TestDoubleVoteMessages(t *testing.T) {
+	mapper := NewCometBFTMapper("test-chain")
+	canonical := &abstraction.CanonicalMessage{
+		ChainID:   "test-chain",
+		Height:    big.NewInt(5),
+		Round:     big.NewInt(1),
+		Timestamp: time.Now().UTC(),
+		Type:      abstraction.MsgTypePrevote,
+		BlockHash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		Validator: "validator-1",
+		Signature: "sig-1",
+	}
+
+	opts := ByzantineOptions{AlternateBlockHash: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"}
+	raws, err := mapper.FromCanonicalByzantine(canonical, ByzantineActionDoubleVote, opts)
+	if err != nil {
+		t.Fatalf("double vote conversion failed: %v", err)
+	}
+	if len(raws) != 2 {
+		t.Fatalf("expected 2 raw messages, got %d", len(raws))
+	}
+
+	var first, second CometBFTConsensusMessage
+	if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
+		t.Fatalf("failed to unmarshal first payload: %v", err)
+	}
+	if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
+		t.Fatalf("failed to unmarshal second payload: %v", err)
+	}
+
+	if first.MessageType != "Vote" || second.MessageType != "Vote" {
+		t.Fatalf("expected vote message types, got %s and %s", first.MessageType, second.MessageType)
+	}
+	if first.BlockID.Hash != canonical.BlockHash {
+		t.Fatalf("expected original hash in first vote, got %s", first.BlockID.Hash)
+	}
+	if second.BlockID.Hash != opts.AlternateBlockHash {
+		t.Fatalf("expected alternate hash in second vote, got %s", second.BlockID.Hash)
+	}
+	if first.Type != 1 || second.Type != 1 {
+		t.Fatalf("expected prevote type 1 for both messages, got %d and %d", first.Type, second.Type)
+	}
+}
+
+func TestDoubleProposalMessages(t *testing.T) {
+	mapper := NewCometBFTMapper("test-chain")
+	canonical := &abstraction.CanonicalMessage{
+		ChainID:   "test-chain",
+		Height:    big.NewInt(10),
+		Round:     big.NewInt(0),
+		Timestamp: time.Now().UTC(),
+		Type:      abstraction.MsgTypeProposal,
+		BlockHash: "1111111111111111111111111111111111111111111111111111111111111111",
+		PrevHash:  "2222222222222222222222222222222222222222222222222222222222222222",
+		Proposer:  "proposer-1",
+		Signature: "sig-1",
+	}
+
+	opts := ByzantineOptions{
+		AlternateBlockHash: "3333333333333333333333333333333333333333333333333333333333333333",
+		AlternatePrevHash:  "4444444444444444444444444444444444444444444444444444444444444444",
+		AlternateSignature: "sig-2",
+	}
+	raws, err := mapper.FromCanonicalByzantine(canonical, ByzantineActionDoubleProposal, opts)
+	if err != nil {
+		t.Fatalf("double proposal conversion failed: %v", err)
+	}
+	if len(raws) != 2 {
+		t.Fatalf("expected 2 raw messages, got %d", len(raws))
+	}
+
+	var first, second CometBFTConsensusMessage
+	if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
+		t.Fatalf("failed to unmarshal first payload: %v", err)
+	}
+	if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
+		t.Fatalf("failed to unmarshal second payload: %v", err)
+	}
+
+	if first.BlockID.Hash != canonical.BlockHash {
+		t.Fatalf("expected original block hash, got %s", first.BlockID.Hash)
+	}
+	if first.BlockID.PrevHash != canonical.PrevHash {
+		t.Fatalf("expected original prev hash, got %s", first.BlockID.PrevHash)
+	}
+	if first.Signature != canonical.Signature {
+		t.Fatalf("expected original signature, got %s", first.Signature)
+	}
+
+	if second.BlockID.Hash != opts.AlternateBlockHash {
+		t.Fatalf("expected alternate block hash, got %s", second.BlockID.Hash)
+	}
+	if second.BlockID.PrevHash != opts.AlternatePrevHash {
+		t.Fatalf("expected alternate prev hash, got %s", second.BlockID.PrevHash)
+	}
+	if second.Signature != opts.AlternateSignature {
+		t.Fatalf("expected alternate signature, got %s", second.Signature)
+	}
+}
+
+func TestInvalidByzantineActionOnProposal(t *testing.T) {
+	mapper := NewCometBFTMapper("test-chain")
+	canonical := &abstraction.CanonicalMessage{
+		ChainID:   "test-chain",
+		Height:    big.NewInt(10),
+		Round:     big.NewInt(0),
+		Timestamp: time.Now().UTC(),
+		Type:      abstraction.MsgTypeProposal,
+	}
+
+	if _, err := mapper.FromCanonicalByzantine(canonical, ByzantineActionDoubleVote, ByzantineOptions{}); err == nil {
+		t.Fatalf("expected error when applying double vote to a proposal message")
+	}
+}


### PR DESCRIPTION
## Summary
- extend the CometBFT mapper with a byzantine conversion path that can emit double votes or conflicting proposals
- add a CLI for loading canonical messages, applying the requested byzantine action, and exporting mutated CometBFT payloads
- cover the new behaviors with adapter-level unit tests

## Testing
- go test ./cometbft/adapter -v

------
https://chatgpt.com/codex/tasks/task_e_68f49dd0a574832bb34ebd53be6f7c8d