### PR TITLE
Expose canonical byzantine mutations in CLI and mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ go run cmd/demo/main.go
 - Lists the available scenarios (`simulation`, `vote-batch`, `byzantine`).
 - `-scenario=simulation` streams synthetic CometBFT messages through the canonical mapper.
 - `-scenario=vote-batch` replays fixtures from `examples/cometbft/Vote.json` and validates the round-trip.
-- `-scenario=byzantine` forges double votes or proposals from a canonical payload using the byzantine mapper.
+- `-scenario=byzantine` forges double votes or proposals via the **canonical → byz-canonical → byzcomet** pipeline and prints each stage of the mutation.
+
+To script the same pipeline, use `cmd/byzantine` which emits JSON containing both the byz-canonical mutations and their encoded CometBFT counterparts.
 
 ### 4. Execute tests
 ```bash

--- a/cmd/demo/README.md
+++ b/cmd/demo/README.md
@@ -4,7 +4,7 @@ This CLI showcases how the PBFT canonical mapper powers different kinds of Comet
 
 1. **simulation** – Streams randomly generated CometBFT messages through the canonical mapper so you can inspect the round-trip flow.
 2. **vote-batch** – Replays fixtures from `examples/cometbft/Vote.json` and verifies that they survive a canonical round-trip.
-3. **byzantine** – Loads a canonical message (either from a file or derived from the fixtures) and emits forged CometBFT payloads using the byzantine pipeline.
+3. **byzantine** – Loads a canonical message (either from a file or derived from the fixtures), materializes one or more **byz-canonical** mutations, and then re-encodes them into forged CometBFT payloads.
 
 ## Usage
 
@@ -22,7 +22,15 @@ go run cmd/demo/main.go -scenario=vote-batch
 go run cmd/demo/main.go -scenario=byzantine -action=double-proposal
 ```
 
-You can provide your own canonical input for the byzantine scenario using `-canonical=/path/to/canonical.json`. Optional flags `-alternate-block`, `-alternate-prev`, and `-alternate-signature` override the forged fields when you need explicit values.
+You can provide your own canonical input for the byzantine scenario using `-canonical=/path/to/canonical.json`. Optional flags `-alternate-block`, `-alternate-prev`, and `-alternate-signature` override the forged fields when you need explicit values. During execution the CLI prints the **canonical → byz-canonical → byzcomet** progression so you can inspect each stage of the mutation.
+
+### Understanding the byzantine pipeline
+
+1. Start with a canonical vote or proposal (from fixtures or your own data).
+2. Call `ApplyByzantineCanonical` to emit one or more mutated **byz-canonical** payloads.
+3. Feed each byz-canonical payload through `mapper.FromCanonical` to obtain the forged CometBFT (`byzcomet`) messages.
+
+The `cmd/demo` byzantine scenario prints each step, while `cmd/byzantine` can serialize the same structure as JSON for scripting or archival.
 
 ## Output snapshot
 

--- a/cmd/demo/byzantine.go
+++ b/cmd/demo/byzantine.go
@@ -36,18 +36,27 @@ func runByzantineScenario(mapper *cometbftAdapter.CometBFTMapper, actionFlag, ca
 		AlternateSignature: alternateSig,
 	}
 
-	rawMessages, err := mapper.FromCanonicalByzantine(canonical, action, opts)
+	byzCanonicals, err := cometbftAdapter.ApplyByzantineCanonical(canonical, action, opts)
 	if err != nil {
 		fmt.Printf("byzantine conversion failed: %v\n", err)
 		return
 	}
 
-	for i, raw := range rawMessages {
+	for i, byzCanonical := range byzCanonicals {
+		fmt.Printf("\nByz-canonical #%d\n", i+1)
+		printCanonicalMessage(byzCanonical)
+
+		raw, err := mapper.FromCanonical(byzCanonical)
+		if err != nil {
+			fmt.Printf("failed to encode byz-canonical #%d: %v\n", i+1, err)
+			return
+		}
+
 		fmt.Printf("\nForged message #%d (%s)\n", i+1, strings.ToUpper(raw.MessageType))
 		printRawMessage(*raw)
 	}
 
-	fmt.Printf("\nGenerated %d CometBFT messages via action %s.\n", len(rawMessages), action)
+	fmt.Printf("\nGenerated %d CometBFT messages via action %s.\n", len(byzCanonicals), action)
 }
 
 func loadCanonicalForScenario(mapper *cometbftAdapter.CometBFTMapper, canonicalPath string) (*abstraction.CanonicalMessage, string, error) {


### PR DESCRIPTION
## Summary
- add an ApplyByzantineCanonical helper that returns byz-canonical payloads and refactor the mapper to consume it
- extend tests to cover canonical mutations alongside the encoded CometBFT messages
- update the byzantine CLIs and documentation to describe the canonical → byz-canonical → byzcomet flow

## Testing
- go test ./cometbft/adapter

------
https://chatgpt.com/codex/tasks/task_e_68fba387c400832ba3b332d1d2af4a66