### PR TITLE
Expand Byzantine mutation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,22 @@ go run cmd/demo/main.go
 - Lists the available scenarios (`simulation`, `vote-batch`, `byzantine`).
 - `-scenario=simulation` streams synthetic CometBFT messages through the canonical mapper.
 - `-scenario=vote-batch` replays fixtures from `examples/cometbft/Vote.json` and validates the round-trip.
-- `-scenario=byzantine` forges double votes or proposals via the **canonical → byz-canonical → byzcomet** pipeline and prints each stage of the mutation.
+- `-scenario=byzantine` forges mutated payloads via the **canonical → byz-canonical → byzcomet** pipeline and prints each stage of the mutation.
+- Actions supported by the byzantine pipeline include `double_vote`, `double_proposal`, `alter_validator`, `drop_signature`, `timestamp_skew`, and `none`.
+- Tunable flags such as `-alternate-block`, `-alternate-prev`, `-alternate-signature`, `-alternate-validator`, `-round-offset`, `-height-offset`, and `-timestamp-skew` control the resulting forged payloads.
+
+Example explorations:
+
+```bash
+# Emit a conflicting prevote that bumps height/round and swaps the validator
+go run cmd/demo/main.go -scenario=byzantine -action=alter_validator -alternate-validator=validator-9 -round-offset=1 -height-offset=2
+
+# Produce a timestamp-skewed proposal with custom hashes
+go run cmd/demo/main.go -scenario=byzantine -action=timestamp_skew -timestamp-skew=250ms -alternate-block=0xDEADBEEF -alternate-prev=0xFEEDFACE
+
+# Generate a double vote while forcing an explicit signature override
+go run cmd/demo/main.go -scenario=byzantine -action=double_vote -alternate-signature=fake-signature
+```
 
 To script the same pipeline, use `cmd/byzantine` which emits JSON containing both the byz-canonical mutations and their encoded CometBFT counterparts.
 

--- a/cmd/byzantine/main.go
+++ b/cmd/byzantine/main.go
@@ -29,11 +29,15 @@ type pipelineOutput struct {
 
 func main() {
 	inputPath := flag.String("input", "", "Path to a canonical message JSON file")
-	actionFlag := flag.String("action", string(cometbftAdapter.ByzantineActionDoubleVote), "Byzantine action to apply (double-vote|double-proposal|none)")
+	actionFlag := flag.String("action", string(cometbftAdapter.ByzantineActionDoubleVote), "Byzantine action to apply (double_vote|double_proposal|alter_validator|drop_signature|timestamp_skew|none)")
 	chainID := flag.String("chain-id", "cosmos-hub-4", "Chain identifier used when re-encoding the message")
 	alternateBlock := flag.String("alternate-block", "", "Alternate block hash to use for the forged message")
 	alternatePrev := flag.String("alternate-prev-hash", "", "Alternate previous block hash (used for proposals)")
 	alternateSig := flag.String("alternate-signature", "", "Alternate signature to attach to the forged message")
+	alternateValidator := flag.String("alternate-validator", "", "Alternate validator/proposer ID applied by alter_validator")
+	roundOffset := flag.Int("round-offset", 0, "Offset (positive or negative) applied to the canonical round")
+	heightOffset := flag.Int("height-offset", 0, "Offset (positive or negative) applied to the canonical height")
+	timestampSkew := flag.Duration("timestamp-skew", 0, "Duration added to canonical timestamps when mutating messages")
 	outputPath := flag.String("output", "", "Optional path to write the resulting CometBFT messages as JSON")
 	flag.Parse()
 
@@ -60,6 +64,10 @@ func main() {
 		AlternateBlockHash: *alternateBlock,
 		AlternatePrevHash:  *alternatePrev,
 		AlternateSignature: *alternateSig,
+		AlternateValidator: *alternateValidator,
+		RoundOffset:        int64(*roundOffset),
+		HeightOffset:       int64(*heightOffset),
+		TimestampShift:     *timestampSkew,
 	}
 
 	byzCanonicals, err := cometbftAdapter.ApplyByzantineCanonical(canonical, action, opts)

--- a/cmd/demo/README.md
+++ b/cmd/demo/README.md
@@ -4,7 +4,7 @@ This CLI showcases how the PBFT canonical mapper powers different kinds of Comet
 
 1. **simulation** – Streams randomly generated CometBFT messages through the canonical mapper so you can inspect the round-trip flow.
 2. **vote-batch** – Replays fixtures from `examples/cometbft/Vote.json` and verifies that they survive a canonical round-trip.
-3. **byzantine** – Loads a canonical message (either from a file or derived from the fixtures), materializes one or more **byz-canonical** mutations, and then re-encodes them into forged CometBFT payloads.
+3. **byzantine** – Loads a canonical message (either from a file or derived from the fixtures), materializes one or more **byz-canonical** mutations (double votes, proposal forks, validator swaps, signature drops, timestamp skews, etc.), and then re-encodes them into forged CometBFT payloads.
 
 ## Usage
 
@@ -19,10 +19,13 @@ go run cmd/demo/main.go -scenario=simulation -duration=15s
 go run cmd/demo/main.go -scenario=vote-batch
 
 # Forge double proposals derived from the fixtures
-go run cmd/demo/main.go -scenario=byzantine -action=double-proposal
+go run cmd/demo/main.go -scenario=byzantine -action=double_proposal
+
+# Swap the validator and bump round/height with a single command
+go run cmd/demo/main.go -scenario=byzantine -action=alter_validator -alternate-validator=validator-9 -round-offset=1 -height-offset=2
 ```
 
-You can provide your own canonical input for the byzantine scenario using `-canonical=/path/to/canonical.json`. Optional flags `-alternate-block`, `-alternate-prev`, and `-alternate-signature` override the forged fields when you need explicit values. During execution the CLI prints the **canonical → byz-canonical → byzcomet** progression so you can inspect each stage of the mutation.
+You can provide your own canonical input for the byzantine scenario using `-canonical=/path/to/canonical.json`. Optional flags `-alternate-block`, `-alternate-prev`, `-alternate-signature`, `-alternate-validator`, `-round-offset`, `-height-offset`, and `-timestamp-skew` override the forged fields when you need explicit values. During execution the CLI prints the **canonical → byz-canonical → byzcomet** progression so you can inspect each stage of the mutation.
 
 ### Understanding the byzantine pipeline
 
@@ -46,7 +49,7 @@ Scenarios:
 Example usage:
   go run cmd/demo/main.go -scenario=simulation -duration=15s
   go run cmd/demo/main.go -scenario=vote-batch
-  go run cmd/demo/main.go -scenario=byzantine -action=double-proposal
+  go run cmd/demo/main.go -scenario=byzantine -action=double_proposal
 
 🧪 CometBFT Vote Round-Trip
 ===========================

--- a/cmd/demo/byzantine.go
+++ b/cmd/demo/byzantine.go
@@ -11,7 +11,7 @@ import (
 	"codec/message/abstraction"
 )
 
-func runByzantineScenario(mapper *cometbftAdapter.CometBFTMapper, actionFlag, canonicalPath, alternateBlock, alternatePrev, alternateSig string) {
+func runByzantineScenario(mapper *cometbftAdapter.CometBFTMapper, actionFlag, canonicalPath, alternateBlock, alternatePrev, alternateSig, alternateValidator string, roundOffset, heightOffset int64, timestampSkew time.Duration) {
 	fmt.Println("🧨 Byzantine Message Emission")
 	fmt.Println("============================")
 
@@ -34,6 +34,10 @@ func runByzantineScenario(mapper *cometbftAdapter.CometBFTMapper, actionFlag, ca
 		AlternateBlockHash: alternateBlock,
 		AlternatePrevHash:  alternatePrev,
 		AlternateSignature: alternateSig,
+		AlternateValidator: alternateValidator,
+		RoundOffset:        roundOffset,
+		HeightOffset:       heightOffset,
+		TimestampShift:     timestampSkew,
 	}
 
 	byzCanonicals, err := cometbftAdapter.ApplyByzantineCanonical(canonical, action, opts)

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -20,12 +20,16 @@ const (
 func main() {
 	scenario := flag.String("scenario", scenarioOverview, "Scenario to run (overview|simulation|vote-batch|byzantine)")
 	duration := flag.Duration("duration", 12*time.Second, "Duration for the live simulation scenario")
-	actionFlag := flag.String("action", string(cometbftAdapter.ByzantineActionDoubleVote), "Byzantine action to apply (double-vote|double-proposal|none)")
+	actionFlag := flag.String("action", string(cometbftAdapter.ByzantineActionDoubleVote), "Byzantine action to apply (double_vote|double_proposal|alter_validator|drop_signature|timestamp_skew|none)")
 	canonicalPath := flag.String("canonical", "", "Path to a canonical message JSON file for the byzantine scenario")
 	chainID := flag.String("chain-id", "cosmos-hub-4", "Chain identifier used when re-encoding messages")
 	alternateBlock := flag.String("alternate-block", "", "Alternate block hash used for forged outputs")
 	alternatePrev := flag.String("alternate-prev", "", "Alternate previous block hash used for forged proposals")
 	alternateSig := flag.String("alternate-signature", "", "Alternate signature applied to forged messages")
+	alternateValidator := flag.String("alternate-validator", "", "Alternate validator/proposer ID used by alter_validator")
+	roundOffset := flag.Int("round-offset", 0, "Offset (positive or negative) applied to the canonical round")
+	heightOffset := flag.Int("height-offset", 0, "Offset (positive or negative) applied to the canonical height")
+	timestampSkew := flag.Duration("timestamp-skew", 0, "Duration added to canonical timestamps during mutation")
 	flag.Parse()
 
 	mapper := cometbftAdapter.NewCometBFTMapper(*chainID)
@@ -38,7 +42,7 @@ func main() {
 	case scenarioVoteBatch:
 		runVoteBatchScenario(mapper)
 	case scenarioByzantine:
-		runByzantineScenario(mapper, *actionFlag, *canonicalPath, *alternateBlock, *alternatePrev, *alternateSig)
+		runByzantineScenario(mapper, *actionFlag, *canonicalPath, *alternateBlock, *alternatePrev, *alternateSig, *alternateValidator, int64(*roundOffset), int64(*heightOffset), *timestampSkew)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown scenario %q\n", *scenario)
 		os.Exit(1)
@@ -57,5 +61,5 @@ func printOverview() {
 	fmt.Println("Example usage:")
 	fmt.Println("  go run cmd/demo/main.go -scenario=simulation -duration=15s")
 	fmt.Println("  go run cmd/demo/main.go -scenario=vote-batch")
-	fmt.Println("  go run cmd/demo/main.go -scenario=byzantine -action=double-proposal")
+	fmt.Println("  go run cmd/demo/main.go -scenario=byzantine -action=double_proposal")
 }

--- a/cometbft/adapter/byzantine.go
+++ b/cometbft/adapter/byzantine.go
@@ -19,6 +19,12 @@ const (
 	ByzantineActionDoubleVote ByzantineAction = "double_vote"
 	// ByzantineActionDoubleProposal emits two proposal messages that reference different blocks.
 	ByzantineActionDoubleProposal ByzantineAction = "double_proposal"
+	// ByzantineActionAlterValidator rewrites the validator or proposer identity.
+	ByzantineActionAlterValidator ByzantineAction = "alter_validator"
+	// ByzantineActionDropSignature removes the signature from the message.
+	ByzantineActionDropSignature ByzantineAction = "drop_signature"
+	// ByzantineActionTimestampSkew applies a timestamp shift to the message.
+	ByzantineActionTimestampSkew ByzantineAction = "timestamp_skew"
 )
 
 // ByzantineOptions contains optional overrides for the mutated messages.
@@ -26,6 +32,10 @@ type ByzantineOptions struct {
 	AlternateBlockHash string
 	AlternatePrevHash  string
 	AlternateSignature string
+	AlternateValidator string
+	RoundOffset        int64
+	HeightOffset       int64
+	TimestampShift     time.Duration
 }
 
 // ParseByzantineAction converts a CLI string to the typed action.
@@ -37,6 +47,12 @@ func ParseByzantineAction(value string) (ByzantineAction, error) {
 		return ByzantineActionDoubleVote, nil
 	case string(ByzantineActionDoubleProposal):
 		return ByzantineActionDoubleProposal, nil
+	case string(ByzantineActionAlterValidator):
+		return ByzantineActionAlterValidator, nil
+	case string(ByzantineActionDropSignature):
+		return ByzantineActionDropSignature, nil
+	case string(ByzantineActionTimestampSkew):
+		return ByzantineActionTimestampSkew, nil
 	default:
 		return ByzantineActionNone, fmt.Errorf("unknown byzantine action: %s", value)
 	}
@@ -49,46 +65,19 @@ func ApplyByzantineCanonical(msg *abstraction.CanonicalMessage, action Byzantine
 		return nil, fmt.Errorf("canonical message cannot be nil")
 	}
 
-	base := cloneCanonicalMessage(msg)
-
 	switch action {
 	case ByzantineActionNone:
-		return []*abstraction.CanonicalMessage{base}, nil
+		return []*abstraction.CanonicalMessage{cloneCanonicalMessage(msg)}, nil
 	case ByzantineActionDoubleVote:
-		if msg.Type != abstraction.MsgTypePrevote && msg.Type != abstraction.MsgTypePrecommit && msg.Type != abstraction.MsgTypeVote {
-			return nil, fmt.Errorf("double_vote action requires a vote canonical message")
-		}
-
-		mutated := cloneCanonicalMessage(msg)
-		mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
-		if opts.AlternateSignature != "" {
-			mutated.Signature = opts.AlternateSignature
-		}
-		if mutated.Timestamp.Equal(msg.Timestamp) {
-			mutated.Timestamp = mutated.Timestamp.Add(1 * time.Millisecond)
-		}
-
-		return []*abstraction.CanonicalMessage{base, mutated}, nil
+		return applyDoubleVoteMutation(msg, opts)
 	case ByzantineActionDoubleProposal:
-		if msg.Type != abstraction.MsgTypeProposal {
-			return nil, fmt.Errorf("double_proposal action requires a proposal canonical message")
-		}
-
-		mutated := cloneCanonicalMessage(msg)
-		mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
-		if opts.AlternatePrevHash != "" {
-			mutated.PrevHash = opts.AlternatePrevHash
-		} else if mutated.PrevHash == msg.PrevHash {
-			mutated.PrevHash = chooseAlternateHash(msg.PrevHash, "")
-		}
-		if opts.AlternateSignature != "" {
-			mutated.Signature = opts.AlternateSignature
-		}
-		if mutated.Timestamp.Equal(msg.Timestamp) {
-			mutated.Timestamp = mutated.Timestamp.Add(1 * time.Millisecond)
-		}
-
-		return []*abstraction.CanonicalMessage{base, mutated}, nil
+		return applyDoubleProposalMutation(msg, opts)
+	case ByzantineActionAlterValidator:
+		return applyAlterValidatorMutation(msg, opts)
+	case ByzantineActionDropSignature:
+		return applyDropSignatureMutation(msg, opts)
+	case ByzantineActionTimestampSkew:
+		return applyTimestampSkewMutation(msg, opts)
 	default:
 		return nil, fmt.Errorf("unsupported byzantine action: %s", action)
 	}
@@ -182,4 +171,123 @@ func cloneCanonicalMessage(msg *abstraction.CanonicalMessage) *abstraction.Canon
 		cloned.RawPayload = append([]byte(nil), msg.RawPayload...)
 	}
 	return &cloned
+}
+
+func applyDoubleVoteMutation(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.CanonicalMessage, error) {
+	if msg.Type != abstraction.MsgTypePrevote && msg.Type != abstraction.MsgTypePrecommit && msg.Type != abstraction.MsgTypeVote {
+		return nil, fmt.Errorf("double_vote action requires a vote canonical message")
+	}
+
+	original := cloneCanonicalMessage(msg)
+	mutated := cloneCanonicalMessage(msg)
+	mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
+	if opts.AlternateSignature != "" {
+		mutated.Signature = opts.AlternateSignature
+	}
+
+	applyCommonMutations(mutated, opts)
+	ensureTimestampProgress(mutated, msg.Timestamp)
+
+	return []*abstraction.CanonicalMessage{original, mutated}, nil
+}
+
+func applyDoubleProposalMutation(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.CanonicalMessage, error) {
+	if msg.Type != abstraction.MsgTypeProposal {
+		return nil, fmt.Errorf("double_proposal action requires a proposal canonical message")
+	}
+
+	original := cloneCanonicalMessage(msg)
+	mutated := cloneCanonicalMessage(msg)
+	mutated.BlockHash = chooseAlternateHash(msg.BlockHash, opts.AlternateBlockHash)
+	if opts.AlternatePrevHash != "" {
+		mutated.PrevHash = opts.AlternatePrevHash
+	} else if mutated.PrevHash == msg.PrevHash {
+		mutated.PrevHash = chooseAlternateHash(msg.PrevHash, "")
+	}
+	if opts.AlternateSignature != "" {
+		mutated.Signature = opts.AlternateSignature
+	}
+
+	applyCommonMutations(mutated, opts)
+	ensureTimestampProgress(mutated, msg.Timestamp)
+
+	return []*abstraction.CanonicalMessage{original, mutated}, nil
+}
+
+func applyAlterValidatorMutation(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.CanonicalMessage, error) {
+	if opts.AlternateValidator == "" {
+		return nil, fmt.Errorf("alter_validator action requires AlternateValidator to be set")
+	}
+
+	mutated := cloneCanonicalMessage(msg)
+	switch msg.Type {
+	case abstraction.MsgTypePrevote, abstraction.MsgTypePrecommit, abstraction.MsgTypeVote:
+		mutated.Validator = opts.AlternateValidator
+	case abstraction.MsgTypeProposal:
+		mutated.Proposer = opts.AlternateValidator
+	default:
+		return nil, fmt.Errorf("alter_validator action requires a proposal or vote canonical message")
+	}
+
+	applyCommonMutations(mutated, opts)
+	ensureTimestampProgress(mutated, msg.Timestamp)
+
+	return []*abstraction.CanonicalMessage{mutated}, nil
+}
+
+func applyDropSignatureMutation(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.CanonicalMessage, error) {
+	mutated := cloneCanonicalMessage(msg)
+	mutated.Signature = ""
+
+	applyCommonMutations(mutated, opts)
+	ensureTimestampProgress(mutated, msg.Timestamp)
+
+	return []*abstraction.CanonicalMessage{mutated}, nil
+}
+
+func applyTimestampSkewMutation(msg *abstraction.CanonicalMessage, opts ByzantineOptions) ([]*abstraction.CanonicalMessage, error) {
+	if opts.TimestampShift == 0 {
+		return nil, fmt.Errorf("timestamp_skew action requires TimestampShift to be non-zero")
+	}
+
+	mutated := cloneCanonicalMessage(msg)
+	applyCommonMutations(mutated, opts)
+	ensureTimestampProgress(mutated, msg.Timestamp)
+
+	return []*abstraction.CanonicalMessage{mutated}, nil
+}
+
+func applyCommonMutations(target *abstraction.CanonicalMessage, opts ByzantineOptions) {
+	if opts.HeightOffset != 0 {
+		target.Height = shiftBigInt(target.Height, opts.HeightOffset)
+	}
+	if opts.RoundOffset != 0 {
+		target.Round = shiftBigInt(target.Round, opts.RoundOffset)
+	}
+	if opts.TimestampShift != 0 {
+		target.Timestamp = target.Timestamp.Add(opts.TimestampShift)
+	}
+}
+
+func ensureTimestampProgress(mutated *abstraction.CanonicalMessage, original time.Time) {
+	if original.IsZero() {
+		return
+	}
+	if mutated.Timestamp.Equal(original) {
+		mutated.Timestamp = mutated.Timestamp.Add(1 * time.Millisecond)
+	}
+}
+
+func shiftBigInt(value *big.Int, offset int64) *big.Int {
+	if offset == 0 {
+		if value == nil {
+			return nil
+		}
+		return new(big.Int).Set(value)
+	}
+
+	if value == nil {
+		return big.NewInt(offset)
+	}
+	return new(big.Int).Add(value, big.NewInt(offset))
 }

--- a/cometbft/adapter/byzantine_test.go
+++ b/cometbft/adapter/byzantine_test.go
@@ -9,57 +9,26 @@ import (
 	"codec/message/abstraction"
 )
 
-func TestApplyByzantineCanonicalDoubleVote(t *testing.T) {
-	timestamp := time.Unix(1700000000, 0).UTC()
-	canonical := &abstraction.CanonicalMessage{
+func TestApplyByzantineCanonical(t *testing.T) {
+	voteTimestamp := time.Unix(1700000000, 0).UTC()
+	proposalTimestamp := time.Unix(1700005000, 0).UTC()
+
+	voteCanonical := &abstraction.CanonicalMessage{
 		ChainID:   "test-chain",
 		Height:    big.NewInt(5),
 		Round:     big.NewInt(1),
-		Timestamp: timestamp,
+		Timestamp: voteTimestamp,
 		Type:      abstraction.MsgTypePrevote,
 		BlockHash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		Validator: "validator-1",
 		Signature: "sig-1",
 	}
 
-	opts := ByzantineOptions{AlternateBlockHash: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", AlternateSignature: "sig-2"}
-	canonicals, err := ApplyByzantineCanonical(canonical, ByzantineActionDoubleVote, opts)
-	if err != nil {
-		t.Fatalf("apply byzantine canonical failed: %v", err)
-	}
-	if len(canonicals) != 2 {
-		t.Fatalf("expected 2 canonical messages, got %d", len(canonicals))
-	}
-	if canonicals[0] == canonical {
-		t.Fatalf("expected cloned canonical message, not the original pointer")
-	}
-	if canonicals[0].BlockHash != canonical.BlockHash {
-		t.Fatalf("expected original block hash, got %s", canonicals[0].BlockHash)
-	}
-
-	mutated := canonicals[1]
-	if mutated.BlockHash != opts.AlternateBlockHash {
-		t.Fatalf("expected alternate hash in mutated vote, got %s", mutated.BlockHash)
-	}
-	if mutated.Signature != opts.AlternateSignature {
-		t.Fatalf("expected alternate signature, got %s", mutated.Signature)
-	}
-	if !mutated.Timestamp.After(canonical.Timestamp) {
-		t.Fatalf("expected mutated timestamp to advance beyond the original")
-	}
-
-	if canonical.BlockHash != "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" {
-		t.Fatalf("original canonical message should remain unchanged")
-	}
-}
-
-func TestApplyByzantineCanonicalDoubleProposal(t *testing.T) {
-	timestamp := time.Unix(1700005000, 0).UTC()
-	canonical := &abstraction.CanonicalMessage{
+	proposalCanonical := &abstraction.CanonicalMessage{
 		ChainID:   "test-chain",
 		Height:    big.NewInt(10),
 		Round:     big.NewInt(0),
-		Timestamp: timestamp,
+		Timestamp: proposalTimestamp,
 		Type:      abstraction.MsgTypeProposal,
 		BlockHash: "1111111111111111111111111111111111111111111111111111111111111111",
 		PrevHash:  "2222222222222222222222222222222222222222222222222222222222222222",
@@ -67,86 +36,225 @@ func TestApplyByzantineCanonicalDoubleProposal(t *testing.T) {
 		Signature: "sig-1",
 	}
 
-	opts := ByzantineOptions{
-		AlternateBlockHash: "3333333333333333333333333333333333333333333333333333333333333333",
-		AlternatePrevHash:  "4444444444444444444444444444444444444444444444444444444444444444",
-		AlternateSignature: "sig-2",
+	tests := []struct {
+		name    string
+		msg     *abstraction.CanonicalMessage
+		action  ByzantineAction
+		opts    ByzantineOptions
+		wantLen int
+		wantErr bool
+		assert  func(t *testing.T, canonicals []*abstraction.CanonicalMessage)
+	}{
+		{
+			name:   "double vote with overrides",
+			msg:    voteCanonical,
+			action: ByzantineActionDoubleVote,
+			opts: ByzantineOptions{
+				AlternateBlockHash: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+				AlternateSignature: "sig-2",
+				RoundOffset:        1,
+				HeightOffset:       2,
+				TimestampShift:     2 * time.Millisecond,
+			},
+			wantLen: 2,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				if canonicals[0] == voteCanonical {
+					t.Fatalf("expected cloned canonical message, not original pointer")
+				}
+				if canonicals[0].BlockHash != voteCanonical.BlockHash {
+					t.Fatalf("expected original block hash to remain unchanged, got %s", canonicals[0].BlockHash)
+				}
+				if canonicals[0].Signature != voteCanonical.Signature {
+					t.Fatalf("expected original signature to remain unchanged")
+				}
+
+				mutated := canonicals[1]
+				if mutated.BlockHash != "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" {
+					t.Fatalf("expected alternate block hash, got %s", mutated.BlockHash)
+				}
+				if mutated.Signature != "sig-2" {
+					t.Fatalf("expected alternate signature, got %s", mutated.Signature)
+				}
+				expectedRound := new(big.Int).Add(voteCanonical.Round, big.NewInt(1))
+				if mutated.Round == nil || mutated.Round.Cmp(expectedRound) != 0 {
+					t.Fatalf("expected round %s, got %v", expectedRound, mutated.Round)
+				}
+				expectedHeight := new(big.Int).Add(voteCanonical.Height, big.NewInt(2))
+				if mutated.Height == nil || mutated.Height.Cmp(expectedHeight) != 0 {
+					t.Fatalf("expected height %s, got %v", expectedHeight, mutated.Height)
+				}
+				expectedTimestamp := voteCanonical.Timestamp.Add(2 * time.Millisecond)
+				if !mutated.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, mutated.Timestamp)
+				}
+			},
+		},
+		{
+			name:   "double proposal with overrides",
+			msg:    proposalCanonical,
+			action: ByzantineActionDoubleProposal,
+			opts: ByzantineOptions{
+				AlternateBlockHash: "3333333333333333333333333333333333333333333333333333333333333333",
+				AlternatePrevHash:  "4444444444444444444444444444444444444444444444444444444444444444",
+				AlternateSignature: "sig-2",
+				TimestampShift:     time.Millisecond,
+			},
+			wantLen: 2,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				mutated := canonicals[1]
+				if mutated.BlockHash != "3333333333333333333333333333333333333333333333333333333333333333" {
+					t.Fatalf("expected alternate block hash, got %s", mutated.BlockHash)
+				}
+				if mutated.PrevHash != "4444444444444444444444444444444444444444444444444444444444444444" {
+					t.Fatalf("expected alternate prev hash, got %s", mutated.PrevHash)
+				}
+				if mutated.Signature != "sig-2" {
+					t.Fatalf("expected alternate signature, got %s", mutated.Signature)
+				}
+				expectedTimestamp := proposalCanonical.Timestamp.Add(1 * time.Millisecond)
+				if !mutated.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, mutated.Timestamp)
+				}
+			},
+		},
+		{
+			name:    "alter validator on vote",
+			msg:     voteCanonical,
+			action:  ByzantineActionAlterValidator,
+			opts:    ByzantineOptions{AlternateValidator: "validator-2"},
+			wantLen: 1,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				mutated := canonicals[0]
+				if mutated.Validator != "validator-2" {
+					t.Fatalf("expected validator override, got %s", mutated.Validator)
+				}
+				if !mutated.Timestamp.After(voteCanonical.Timestamp) {
+					t.Fatalf("expected timestamp to advance for altered validator action")
+				}
+			},
+		},
+		{
+			name:    "alter validator on proposal",
+			msg:     proposalCanonical,
+			action:  ByzantineActionAlterValidator,
+			opts:    ByzantineOptions{AlternateValidator: "proposer-2"},
+			wantLen: 1,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				mutated := canonicals[0]
+				if mutated.Proposer != "proposer-2" {
+					t.Fatalf("expected proposer override, got %s", mutated.Proposer)
+				}
+				if !mutated.Timestamp.After(proposalCanonical.Timestamp) {
+					t.Fatalf("expected timestamp to advance for altered proposer action")
+				}
+			},
+		},
+		{
+			name:   "drop signature with offsets",
+			msg:    voteCanonical,
+			action: ByzantineActionDropSignature,
+			opts: ByzantineOptions{
+				RoundOffset:    2,
+				HeightOffset:   -1,
+				TimestampShift: 5 * time.Millisecond,
+			},
+			wantLen: 1,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				mutated := canonicals[0]
+				if mutated.Signature != "" {
+					t.Fatalf("expected signature to be dropped, got %s", mutated.Signature)
+				}
+				expectedRound := new(big.Int).Add(voteCanonical.Round, big.NewInt(2))
+				if mutated.Round == nil || mutated.Round.Cmp(expectedRound) != 0 {
+					t.Fatalf("expected round %s, got %v", expectedRound, mutated.Round)
+				}
+				expectedHeight := new(big.Int).Add(voteCanonical.Height, big.NewInt(-1))
+				if mutated.Height == nil || mutated.Height.Cmp(expectedHeight) != 0 {
+					t.Fatalf("expected height %s, got %v", expectedHeight, mutated.Height)
+				}
+				expectedTimestamp := voteCanonical.Timestamp.Add(5 * time.Millisecond)
+				if !mutated.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, mutated.Timestamp)
+				}
+			},
+		},
+		{
+			name:    "timestamp skew",
+			msg:     proposalCanonical,
+			action:  ByzantineActionTimestampSkew,
+			opts:    ByzantineOptions{TimestampShift: -3 * time.Second},
+			wantLen: 1,
+			assert: func(t *testing.T, canonicals []*abstraction.CanonicalMessage) {
+				mutated := canonicals[0]
+				expectedTimestamp := proposalCanonical.Timestamp.Add(-3 * time.Second)
+				if !mutated.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, mutated.Timestamp)
+				}
+			},
+		},
+		{
+			name:    "double vote wrong type",
+			msg:     proposalCanonical,
+			action:  ByzantineActionDoubleVote,
+			wantErr: true,
+		},
+		{
+			name:    "alter validator missing override",
+			msg:     voteCanonical,
+			action:  ByzantineActionAlterValidator,
+			wantErr: true,
+		},
+		{
+			name:    "timestamp skew missing duration",
+			msg:     voteCanonical,
+			action:  ByzantineActionTimestampSkew,
+			wantErr: true,
+		},
 	}
 
-	canonicals, err := ApplyByzantineCanonical(canonical, ByzantineActionDoubleProposal, opts)
-	if err != nil {
-		t.Fatalf("apply byzantine canonical failed: %v", err)
-	}
-	if len(canonicals) != 2 {
-		t.Fatalf("expected 2 canonical messages, got %d", len(canonicals))
-	}
-
-	mutated := canonicals[1]
-	if mutated.BlockHash != opts.AlternateBlockHash {
-		t.Fatalf("expected alternate block hash, got %s", mutated.BlockHash)
-	}
-	if mutated.PrevHash != opts.AlternatePrevHash {
-		t.Fatalf("expected alternate prev hash, got %s", mutated.PrevHash)
-	}
-	if mutated.Signature != opts.AlternateSignature {
-		t.Fatalf("expected alternate signature, got %s", mutated.Signature)
-	}
-	if !mutated.Timestamp.After(canonical.Timestamp) {
-		t.Fatalf("expected mutated timestamp to advance beyond the original")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			canonicals, err := ApplyByzantineCanonical(tc.msg, tc.action, tc.opts)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ApplyByzantineCanonical returned error: %v", err)
+			}
+			if len(canonicals) != tc.wantLen {
+				t.Fatalf("expected %d canonical messages, got %d", tc.wantLen, len(canonicals))
+			}
+			if tc.assert != nil {
+				tc.assert(t, canonicals)
+			}
+		})
 	}
 }
 
-func TestFromCanonicalByzantineDoubleVoteEncoding(t *testing.T) {
+func TestFromCanonicalByzantine(t *testing.T) {
 	mapper := NewCometBFTMapper("test-chain")
-	canonical := &abstraction.CanonicalMessage{
+	voteTimestamp := time.Unix(1700000000, 0).UTC()
+	proposalTimestamp := time.Unix(1700005000, 0).UTC()
+
+	voteCanonical := &abstraction.CanonicalMessage{
 		ChainID:   "test-chain",
 		Height:    big.NewInt(5),
 		Round:     big.NewInt(1),
-		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Timestamp: voteTimestamp,
 		Type:      abstraction.MsgTypePrevote,
 		BlockHash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		Validator: "validator-1",
 		Signature: "sig-1",
 	}
 
-	opts := ByzantineOptions{AlternateBlockHash: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"}
-	raws, err := mapper.FromCanonicalByzantine(canonical, ByzantineActionDoubleVote, opts)
-	if err != nil {
-		t.Fatalf("double vote conversion failed: %v", err)
-	}
-	if len(raws) != 2 {
-		t.Fatalf("expected 2 raw messages, got %d", len(raws))
-	}
-
-	var first, second CometBFTConsensusMessage
-	if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
-		t.Fatalf("failed to unmarshal first payload: %v", err)
-	}
-	if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
-		t.Fatalf("failed to unmarshal second payload: %v", err)
-	}
-
-	if first.MessageType != "Vote" || second.MessageType != "Vote" {
-		t.Fatalf("expected vote message types, got %s and %s", first.MessageType, second.MessageType)
-	}
-	if first.BlockID.Hash != canonical.BlockHash {
-		t.Fatalf("expected original hash in first vote, got %s", first.BlockID.Hash)
-	}
-	if second.BlockID.Hash != opts.AlternateBlockHash {
-		t.Fatalf("expected alternate hash in second vote, got %s", second.BlockID.Hash)
-	}
-	if first.Type != 1 || second.Type != 1 {
-		t.Fatalf("expected prevote type 1 for both messages, got %d and %d", first.Type, second.Type)
-	}
-}
-
-func TestFromCanonicalByzantineDoubleProposalEncoding(t *testing.T) {
-	mapper := NewCometBFTMapper("test-chain")
-	canonical := &abstraction.CanonicalMessage{
+	proposalCanonical := &abstraction.CanonicalMessage{
 		ChainID:   "test-chain",
 		Height:    big.NewInt(10),
 		Round:     big.NewInt(0),
-		Timestamp: time.Unix(1700005000, 0).UTC(),
+		Timestamp: proposalTimestamp,
 		Type:      abstraction.MsgTypeProposal,
 		BlockHash: "1111111111111111111111111111111111111111111111111111111111111111",
 		PrevHash:  "2222222222222222222222222222222222222222222222222222222222222222",
@@ -154,58 +262,191 @@ func TestFromCanonicalByzantineDoubleProposalEncoding(t *testing.T) {
 		Signature: "sig-1",
 	}
 
-	opts := ByzantineOptions{
-		AlternateBlockHash: "3333333333333333333333333333333333333333333333333333333333333333",
-		AlternatePrevHash:  "4444444444444444444444444444444444444444444444444444444444444444",
-		AlternateSignature: "sig-2",
-	}
-	raws, err := mapper.FromCanonicalByzantine(canonical, ByzantineActionDoubleProposal, opts)
-	if err != nil {
-		t.Fatalf("double proposal conversion failed: %v", err)
-	}
-	if len(raws) != 2 {
-		t.Fatalf("expected 2 raw messages, got %d", len(raws))
+	tests := []struct {
+		name    string
+		msg     *abstraction.CanonicalMessage
+		action  ByzantineAction
+		opts    ByzantineOptions
+		wantLen int
+		assert  func(t *testing.T, raws []*abstraction.RawConsensusMessage)
+	}{
+		{
+			name:   "double vote encoding",
+			msg:    voteCanonical,
+			action: ByzantineActionDoubleVote,
+			opts: ByzantineOptions{
+				AlternateBlockHash: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+				AlternateSignature: "sig-2",
+				RoundOffset:        1,
+				HeightOffset:       2,
+				TimestampShift:     2 * time.Millisecond,
+			},
+			wantLen: 2,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				if len(raws) != 2 {
+					t.Fatalf("expected 2 raw messages, got %d", len(raws))
+				}
+				var first, second CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
+					t.Fatalf("failed to unmarshal first payload: %v", err)
+				}
+				if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
+					t.Fatalf("failed to unmarshal second payload: %v", err)
+				}
+				if first.BlockID.Hash != voteCanonical.BlockHash {
+					t.Fatalf("expected original block hash, got %s", first.BlockID.Hash)
+				}
+				if second.BlockID.Hash != "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" {
+					t.Fatalf("expected alternate block hash, got %s", second.BlockID.Hash)
+				}
+				if second.Signature != "sig-2" {
+					t.Fatalf("expected alternate signature, got %s", second.Signature)
+				}
+				if first.Height != "5" {
+					t.Fatalf("expected original height 5, got %s", first.Height)
+				}
+				if second.Height != "7" {
+					t.Fatalf("expected mutated height 7, got %s", second.Height)
+				}
+				if first.Round != "1" {
+					t.Fatalf("expected original round 1, got %s", first.Round)
+				}
+				if second.Round != "2" {
+					t.Fatalf("expected mutated round 2, got %s", second.Round)
+				}
+				expectedTimestamp := voteCanonical.Timestamp.Add(2 * time.Millisecond)
+				if !second.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, second.Timestamp)
+				}
+			},
+		},
+		{
+			name:   "double proposal encoding",
+			msg:    proposalCanonical,
+			action: ByzantineActionDoubleProposal,
+			opts: ByzantineOptions{
+				AlternateBlockHash: "3333333333333333333333333333333333333333333333333333333333333333",
+				AlternatePrevHash:  "4444444444444444444444444444444444444444444444444444444444444444",
+				AlternateSignature: "sig-2",
+				TimestampShift:     time.Millisecond,
+			},
+			wantLen: 2,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				var first, second CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
+					t.Fatalf("failed to unmarshal first payload: %v", err)
+				}
+				if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
+					t.Fatalf("failed to unmarshal second payload: %v", err)
+				}
+				if second.BlockID.Hash != "3333333333333333333333333333333333333333333333333333333333333333" {
+					t.Fatalf("expected alternate block hash, got %s", second.BlockID.Hash)
+				}
+				if second.BlockID.PrevHash != "4444444444444444444444444444444444444444444444444444444444444444" {
+					t.Fatalf("expected alternate prev hash, got %s", second.BlockID.PrevHash)
+				}
+				if second.Signature != "sig-2" {
+					t.Fatalf("expected alternate signature, got %s", second.Signature)
+				}
+				expectedTimestamp := proposalCanonical.Timestamp.Add(1 * time.Millisecond)
+				if !second.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, second.Timestamp)
+				}
+			},
+		},
+		{
+			name:    "alter validator encoding",
+			msg:     voteCanonical,
+			action:  ByzantineActionAlterValidator,
+			opts:    ByzantineOptions{AlternateValidator: "validator-2"},
+			wantLen: 1,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				var message CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &message); err != nil {
+					t.Fatalf("failed to unmarshal payload: %v", err)
+				}
+				if message.ValidatorAddress != "validator-2" {
+					t.Fatalf("expected validator override, got %s", message.ValidatorAddress)
+				}
+			},
+		},
+		{
+			name:    "alter proposer encoding",
+			msg:     proposalCanonical,
+			action:  ByzantineActionAlterValidator,
+			opts:    ByzantineOptions{AlternateValidator: "proposer-2"},
+			wantLen: 1,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				var message CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &message); err != nil {
+					t.Fatalf("failed to unmarshal payload: %v", err)
+				}
+				if message.ProposerAddress != "proposer-2" {
+					t.Fatalf("expected proposer override, got %s", message.ProposerAddress)
+				}
+			},
+		},
+		{
+			name:   "drop signature encoding",
+			msg:    voteCanonical,
+			action: ByzantineActionDropSignature,
+			opts: ByzantineOptions{
+				RoundOffset:    2,
+				HeightOffset:   -1,
+				TimestampShift: 5 * time.Millisecond,
+			},
+			wantLen: 1,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				var message CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &message); err != nil {
+					t.Fatalf("failed to unmarshal payload: %v", err)
+				}
+				if message.Signature != "" {
+					t.Fatalf("expected signature to be dropped, got %s", message.Signature)
+				}
+				if message.Height != "4" {
+					t.Fatalf("expected mutated height 4, got %s", message.Height)
+				}
+				if message.Round != "3" {
+					t.Fatalf("expected mutated round 3, got %s", message.Round)
+				}
+				expectedTimestamp := voteCanonical.Timestamp.Add(5 * time.Millisecond)
+				if !message.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, message.Timestamp)
+				}
+			},
+		},
+		{
+			name:    "timestamp skew encoding",
+			msg:     proposalCanonical,
+			action:  ByzantineActionTimestampSkew,
+			opts:    ByzantineOptions{TimestampShift: -3 * time.Second},
+			wantLen: 1,
+			assert: func(t *testing.T, raws []*abstraction.RawConsensusMessage) {
+				var message CometBFTConsensusMessage
+				if err := json.Unmarshal(raws[0].Payload, &message); err != nil {
+					t.Fatalf("failed to unmarshal payload: %v", err)
+				}
+				expectedTimestamp := proposalCanonical.Timestamp.Add(-3 * time.Second)
+				if !message.Timestamp.Equal(expectedTimestamp) {
+					t.Fatalf("expected timestamp %s, got %s", expectedTimestamp, message.Timestamp)
+				}
+			},
+		},
 	}
 
-	var first, second CometBFTConsensusMessage
-	if err := json.Unmarshal(raws[0].Payload, &first); err != nil {
-		t.Fatalf("failed to unmarshal first payload: %v", err)
-	}
-	if err := json.Unmarshal(raws[1].Payload, &second); err != nil {
-		t.Fatalf("failed to unmarshal second payload: %v", err)
-	}
-
-	if first.BlockID.Hash != canonical.BlockHash {
-		t.Fatalf("expected original block hash, got %s", first.BlockID.Hash)
-	}
-	if first.BlockID.PrevHash != canonical.PrevHash {
-		t.Fatalf("expected original prev hash, got %s", first.BlockID.PrevHash)
-	}
-	if first.Signature != canonical.Signature {
-		t.Fatalf("expected original signature, got %s", first.Signature)
-	}
-
-	if second.BlockID.Hash != opts.AlternateBlockHash {
-		t.Fatalf("expected alternate block hash, got %s", second.BlockID.Hash)
-	}
-	if second.BlockID.PrevHash != opts.AlternatePrevHash {
-		t.Fatalf("expected alternate prev hash, got %s", second.BlockID.PrevHash)
-	}
-	if second.Signature != opts.AlternateSignature {
-		t.Fatalf("expected alternate signature, got %s", second.Signature)
-	}
-}
-
-func TestInvalidByzantineActionOnProposal(t *testing.T) {
-	canonical := &abstraction.CanonicalMessage{
-		ChainID:   "test-chain",
-		Height:    big.NewInt(10),
-		Round:     big.NewInt(0),
-		Timestamp: time.Unix(1700005000, 0).UTC(),
-		Type:      abstraction.MsgTypeProposal,
-	}
-
-	if _, err := ApplyByzantineCanonical(canonical, ByzantineActionDoubleVote, ByzantineOptions{}); err == nil {
-		t.Fatalf("expected error when applying double vote to a proposal message")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raws, err := mapper.FromCanonicalByzantine(tc.msg, tc.action, tc.opts)
+			if err != nil {
+				t.Fatalf("FromCanonicalByzantine returned error: %v", err)
+			}
+			if len(raws) != tc.wantLen {
+				t.Fatalf("expected %d raw messages, got %d", tc.wantLen, len(raws))
+			}
+			if tc.assert != nil {
+				tc.assert(t, raws)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- extend the CometBFT byzantine action enum with validator, signature, and timestamp mutation helpers and shared mutation utilities
- add CLI flags in cmd/byzantine and cmd/demo for the new overrides and document the expanded scenarios in both READMEs
- replace the adapter byzantine tests with table-driven coverage of each action and the resulting encoded payloads

## Testing
- `go test ./...` *(fails: missing codec/abstraction dependency in unrelated packages)*
- `go test ./cometbft/adapter`


------
https://chatgpt.com/codex/tasks/task_e_68fba903289c832bb163eabbf4cb9e03