### PR TITLE
Add Byzantine proxy engine and CLI

### DIFF
--- a/cmd/byzproxy/main.go
+++ b/cmd/byzproxy/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/proxy/engine"
+
+	"github.com/cometbft/cometbft/p2p"
+)
+
+func main() {
+	var (
+		listenAddr         = flag.String("listen", "tcp://0.0.0.0:26656", "address to accept external peers (tcp://host:port)")
+		upstreamAddr       = flag.String("upstream", "tcp://127.0.0.1:26657", "address of the upstream validator (tcp://host:port)")
+		nodeKeyPath        = flag.String("node-key", "", "path to the node_key.json used for the proxy handshake")
+		chainID            = flag.String("chain-id", "proxy-chain", "chain identifier used for canonical mapping")
+		attack             = flag.String("attack", string(cometbftAdapter.ByzantineActionNone), "byzantine action to apply")
+		triggerHeight      = flag.Int64("trigger-height", 0, "height at which mutations activate (0 disables)")
+		triggerRound       = flag.Int64("trigger-round", 0, "round at which mutations activate (0 disables)")
+		triggerStep        = flag.String("trigger-step", "", "canonical message type (proposal|prevote|precommit) required for mutation")
+		delayDur           = flag.Duration("delay", 0, "delay applied to triggered messages before forwarding")
+		dropMessages       = flag.Bool("drop", false, "drop triggered messages instead of forwarding")
+		duplicate          = flag.Bool("duplicate", false, "duplicate triggered messages after mutation")
+		alternateBlock     = flag.String("alternate-block", "", "alternate block hash used during mutation")
+		alternatePrev      = flag.String("alternate-prev-hash", "", "alternate previous block hash used during mutation")
+		alternateSig       = flag.String("alternate-signature", "", "alternate signature for forged messages")
+		alternateValidator = flag.String("alternate-validator", "", "alternate validator/proposer identifier")
+		roundOffset        = flag.Int64("round-offset", 0, "offset applied to canonical round when mutating")
+		heightOffset       = flag.Int64("height-offset", 0, "offset applied to canonical height when mutating")
+		timestampShift     = flag.Duration("timestamp-skew", 0, "duration applied to canonical timestamps when mutating")
+		dialTimeout        = flag.Duration("dial-timeout", 5*time.Second, "timeout used when dialing the upstream validator")
+		mutateDir          = flag.String("mutate-direction", "upstream", "direction to apply mutations (upstream|downstream|both)")
+	)
+
+	flag.Parse()
+
+	if strings.TrimSpace(*nodeKeyPath) == "" {
+		fmt.Fprintln(os.Stderr, "--node-key is required")
+		os.Exit(1)
+	}
+
+	nodeKey, err := p2p.LoadNodeKey(*nodeKeyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load node key: %v\n", err)
+		os.Exit(1)
+	}
+
+	byzAction, err := cometbftAdapter.ParseByzantineAction(*attack)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid attack type: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts := cometbftAdapter.ByzantineOptions{
+		AlternateBlockHash: *alternateBlock,
+		AlternatePrevHash:  *alternatePrev,
+		AlternateSignature: *alternateSig,
+		AlternateValidator: *alternateValidator,
+		RoundOffset:        *roundOffset,
+		HeightOffset:       *heightOffset,
+		TimestampShift:     *timestampShift,
+	}
+
+	trigger := engine.Trigger{}
+	if *triggerHeight > 0 {
+		trigger.Height = triggerHeight
+	}
+	if *triggerRound > 0 {
+		trigger.Round = triggerRound
+	}
+	if step := strings.TrimSpace(*triggerStep); step != "" {
+		trigger.Step = strings.ToLower(step)
+	}
+
+	hooks := engine.Hooks{
+		Delay:     *delayDur,
+		Drop:      *dropMessages,
+		Duplicate: *duplicate,
+	}
+
+	direction, err := engine.ParseDirection(*mutateDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid mutate direction: %v\n", err)
+		os.Exit(1)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	cfg, err := engine.NewConfig(engine.ConfigOptions{
+		ListenAddress:  *listenAddr,
+		UpstreamTarget: *upstreamAddr,
+		ChainID:        *chainID,
+		NodeKey:        nodeKey,
+		Action:         byzAction,
+		Options:        opts,
+		Trigger:        trigger,
+		Hooks:          hooks,
+		Direction:      direction,
+		DialTimeout:    *dialTimeout,
+		Logger:         logger,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build config: %v\n", err)
+		os.Exit(1)
+	}
+
+	eng := engine.New(cfg)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := eng.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		fmt.Fprintf(os.Stderr, "proxy exited with error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cometbft-0.38.19/go.mod
+++ b/cometbft-0.38.19/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cometbft/cometbft-db v0.14.1
 	github.com/cosmos/gogoproto v1.7.0
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
+        github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/go-kit/kit v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,21 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/ethereum/go-ethereum v1.16.4
-	github.com/fardream/go-bcs v0.9.0
-	github.com/vmihailenco/msgpack/v5 v5.4.1
-	google.golang.org/protobuf v1.36.10
+        github.com/ethereum/go-ethereum v1.16.4
+        github.com/fardream/go-bcs v0.9.0
+        github.com/vmihailenco/msgpack/v5 v5.4.1
+        google.golang.org/protobuf v1.36.10
 )
 
 require (
-	github.com/cometbft/cometbft v1.0.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+        github.com/cometbft/cometbft v1.0.1 // indirect
+        github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+        github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
+        github.com/holiman/uint256 v1.3.2 // indirect
+        github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+        github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+        golang.org/x/crypto v0.36.0 // indirect
+        golang.org/x/sys v0.36.0 // indirect
 )
+
+replace github.com/cometbft/cometbft => ./cometbft-0.38.19

--- a/proxy/engine/config.go
+++ b/proxy/engine/config.go
@@ -1,0 +1,198 @@
+package engine
+
+import (
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/message/abstraction"
+	"github.com/cometbft/cometbft/p2p"
+)
+
+// Direction indicates which link should have mutations applied.
+type Direction int
+
+const (
+	// DirectionUpstream mutates messages originating from the upstream validator before they reach external peers.
+	DirectionUpstream Direction = iota
+	// DirectionDownstream mutates messages heading to the upstream validator.
+	DirectionDownstream
+	// DirectionBoth mutates messages flowing in both directions.
+	DirectionBoth
+)
+
+// ParseDirection parses a textual direction value.
+func ParseDirection(value string) (Direction, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "upstream":
+		return DirectionUpstream, nil
+	case "downstream":
+		return DirectionDownstream, nil
+	case "both":
+		return DirectionBoth, nil
+	default:
+		return DirectionUpstream, fmt.Errorf("unknown direction %q", value)
+	}
+}
+
+// ShouldMutateUpstream reports if messages from the upstream validator should be mutated.
+func (d Direction) ShouldMutateUpstream() bool {
+	return d == DirectionUpstream || d == DirectionBoth
+}
+
+// ShouldMutateDownstream reports if messages heading to the upstream validator should be mutated.
+func (d Direction) ShouldMutateDownstream() bool {
+	return d == DirectionDownstream || d == DirectionBoth
+}
+
+// Trigger describes when the engine should mutate traffic.
+type Trigger struct {
+	Height *int64
+	Round  *int64
+	Step   string
+}
+
+// Matches reports whether the canonical message satisfies the trigger.
+func (t Trigger) Matches(msg *abstraction.CanonicalMessage) bool {
+	if msg == nil {
+		return false
+	}
+	if t.Height != nil {
+		if msg.Height == nil || msg.Height.Int64() != *t.Height {
+			return false
+		}
+	}
+	if t.Round != nil {
+		if msg.Round == nil || msg.Round.Int64() != *t.Round {
+			return false
+		}
+	}
+	if t.Step != "" && strings.ToLower(string(msg.Type)) != t.Step {
+		return false
+	}
+	return true
+}
+
+// Hooks define behavioural mutations around forwarding.
+type Hooks struct {
+	Delay     time.Duration
+	Drop      bool
+	Duplicate bool
+}
+
+// Config holds the runtime configuration for the proxy engine.
+type Config struct {
+	ListenNetwork   string
+	ListenAddress   string
+	UpstreamNetwork string
+	UpstreamAddress string
+
+	ChainID string
+
+	NodeKey *p2p.NodeKey
+
+	Action  cometbftAdapter.ByzantineAction
+	Options cometbftAdapter.ByzantineOptions
+
+	Trigger   Trigger
+	Hooks     Hooks
+	Direction Direction
+
+	DialTimeout time.Duration
+
+	Logger *slog.Logger
+}
+
+// ConfigOptions contains inputs to build a Config.
+type ConfigOptions struct {
+	ListenAddress  string
+	UpstreamTarget string
+	ChainID        string
+	NodeKey        *p2p.NodeKey
+	Action         cometbftAdapter.ByzantineAction
+	Options        cometbftAdapter.ByzantineOptions
+	Trigger        Trigger
+	Hooks          Hooks
+	Direction      Direction
+	DialTimeout    time.Duration
+	Logger         *slog.Logger
+}
+
+// NewConfig validates and normalises proxy options.
+func NewConfig(opts ConfigOptions) (*Config, error) {
+	listenNetwork, listenAddr, err := parseNetworkAddress(opts.ListenAddress)
+	if err != nil {
+		return nil, fmt.Errorf("invalid listen address: %w", err)
+	}
+	upstreamNetwork, upstreamAddr, err := parseNetworkAddress(opts.UpstreamTarget)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upstream address: %w", err)
+	}
+	if opts.NodeKey == nil {
+		return nil, fmt.Errorf("node key is required")
+	}
+	if strings.TrimSpace(opts.ChainID) == "" {
+		return nil, fmt.Errorf("chain id is required")
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+	}
+
+	trigger := Trigger{Step: strings.ToLower(strings.TrimSpace(opts.Trigger.Step))}
+	if opts.Trigger.Height != nil {
+		h := *opts.Trigger.Height
+		trigger.Height = &h
+	}
+	if opts.Trigger.Round != nil {
+		r := *opts.Trigger.Round
+		trigger.Round = &r
+	}
+
+	cfg := &Config{
+		ListenNetwork:   listenNetwork,
+		ListenAddress:   listenAddr,
+		UpstreamNetwork: upstreamNetwork,
+		UpstreamAddress: upstreamAddr,
+		ChainID:         strings.TrimSpace(opts.ChainID),
+		NodeKey:         opts.NodeKey,
+		Action:          opts.Action,
+		Options:         opts.Options,
+		Trigger:         trigger,
+		Hooks:           opts.Hooks,
+		Direction:       opts.Direction,
+		DialTimeout:     opts.DialTimeout,
+		Logger:          logger,
+	}
+
+	if cfg.DialTimeout <= 0 {
+		cfg.DialTimeout = 5 * time.Second
+	}
+
+	return cfg, nil
+}
+
+func parseNetworkAddress(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", fmt.Errorf("address cannot be empty")
+	}
+	if !strings.Contains(raw, "://") {
+		return "tcp", raw, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", "", err
+	}
+	if u.Scheme == "" {
+		return "", "", fmt.Errorf("missing scheme")
+	}
+	if u.Host == "" {
+		return "", "", fmt.Errorf("missing host")
+	}
+	return u.Scheme, u.Host, nil
+}

--- a/proxy/engine/consensus.go
+++ b/proxy/engine/consensus.go
@@ -1,0 +1,242 @@
+package engine
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/message/abstraction"
+	consensuspb "github.com/cometbft/cometbft/proto/tendermint/consensus"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+)
+
+const (
+	stateChannelID       byte = 0x20
+	dataChannelID        byte = 0x21
+	voteChannelID        byte = 0x22
+	voteSetBitsChannelID byte = 0x23
+)
+
+var consensusChannelSet = map[byte]struct{}{
+	stateChannelID:       {},
+	dataChannelID:        {},
+	voteChannelID:        {},
+	voteSetBitsChannelID: {},
+}
+
+var errUnsupportedMessage = errors.New("unsupported consensus message")
+
+type flowDirection string
+
+const (
+	directionUpstream   flowDirection = "upstream"
+	directionDownstream flowDirection = "downstream"
+)
+
+func isConsensusChannel(chID byte) bool {
+	_, ok := consensusChannelSet[chID]
+	return ok
+}
+
+func decodeConsensusMessage(payload []byte) (*consensuspb.Message, error) {
+	var msg consensuspb.Message
+	if err := msg.Unmarshal(payload); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func canonicalFromConsensus(mapper *cometbftAdapter.CometBFTMapper, chainID string, msg *consensuspb.Message) (*abstraction.CanonicalMessage, error) {
+	adapterMsg, messageType, err := adapterMessageFromConsensus(msg)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(adapterMsg)
+	if err != nil {
+		return nil, err
+	}
+	raw := abstraction.RawConsensusMessage{
+		ChainType:   abstraction.ChainTypeCometBFT,
+		ChainID:     chainID,
+		MessageType: messageType,
+		Payload:     payload,
+		Encoding:    "json",
+		Timestamp:   adapterMsg.Timestamp,
+	}
+	return mapper.ToCanonical(raw)
+}
+
+func adapterMessageFromConsensus(msg *consensuspb.Message) (*cometbftAdapter.CometBFTConsensusMessage, string, error) {
+	switch payload := msg.Sum.(type) {
+	case *consensuspb.Message_Proposal:
+		return proposalToAdapter(payload.Proposal)
+	case *consensuspb.Message_Vote:
+		return voteToAdapter(payload.Vote)
+	default:
+		return nil, "", errUnsupportedMessage
+	}
+}
+
+func proposalToAdapter(wrapper *consensuspb.Proposal) (*cometbftAdapter.CometBFTConsensusMessage, string, error) {
+	if wrapper == nil || wrapper.Proposal == nil {
+		return nil, "", fmt.Errorf("empty proposal payload")
+	}
+	p := wrapper.Proposal
+	msg := &cometbftAdapter.CometBFTConsensusMessage{
+		MessageType: "Proposal",
+		Height:      strconv.FormatInt(p.Height, 10),
+		Round:       strconv.FormatInt(int64(p.Round), 10),
+		Timestamp:   p.Timestamp,
+		POLRound:    p.POLRound,
+		Signature:   encodeBase64(p.Signature),
+		BlockID: cometbftAdapter.BlockID{
+			Hash:          hex.EncodeToString(p.BlockID.Hash),
+			PartSetHeader: cometbftAdapter.PartSetHeader{Total: uint32(p.BlockID.PartSetHeader.Total), Hash: append([]byte(nil), p.BlockID.PartSetHeader.Hash...)},
+		},
+	}
+	return msg, msg.MessageType, nil
+}
+
+func voteToAdapter(wrapper *consensuspb.Vote) (*cometbftAdapter.CometBFTConsensusMessage, string, error) {
+	if wrapper == nil || wrapper.Vote == nil {
+		return nil, "", fmt.Errorf("empty vote payload")
+	}
+	v := wrapper.Vote
+	msg := &cometbftAdapter.CometBFTConsensusMessage{
+		MessageType:        "Vote",
+		Type:               int32(v.Type),
+		Height:             strconv.FormatInt(v.Height, 10),
+		Round:              strconv.FormatInt(int64(v.Round), 10),
+		Timestamp:          v.Timestamp,
+		BlockID:            cometbftAdapter.BlockID{Hash: hex.EncodeToString(v.BlockID.Hash), PartSetHeader: cometbftAdapter.PartSetHeader{Total: uint32(v.BlockID.PartSetHeader.Total), Hash: append([]byte(nil), v.BlockID.PartSetHeader.Hash...)}},
+		ValidatorAddress:   hex.EncodeToString(v.ValidatorAddress),
+		ValidatorIndex:     v.ValidatorIndex,
+		Signature:          encodeBase64(v.Signature),
+		Extension:          encodeBase64(v.Extension),
+		ExtensionSignature: encodeBase64(v.ExtensionSignature),
+	}
+	return msg, msg.MessageType, nil
+}
+
+func rawToConsensusMessage(raw *abstraction.RawConsensusMessage) (*consensuspb.Message, error) {
+	var adapterMsg cometbftAdapter.CometBFTConsensusMessage
+	if err := json.Unmarshal(raw.Payload, &adapterMsg); err != nil {
+		return nil, err
+	}
+	return protoFromAdapterMessage(&adapterMsg)
+}
+
+func protoFromAdapterMessage(msg *cometbftAdapter.CometBFTConsensusMessage) (*consensuspb.Message, error) {
+	switch strings.ToLower(msg.MessageType) {
+	case "proposal":
+		height, err := strconv.ParseInt(msg.Height, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proposal height: %w", err)
+		}
+		round, err := strconv.ParseInt(msg.Round, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proposal round: %w", err)
+		}
+		proposal := &cmttypes.Proposal{
+			Type:      cmtproto.ProposalType,
+			Height:    height,
+			Round:     int32(round),
+			POLRound:  msg.POLRound,
+			BlockID:   typesBlockIDFromAdapter(msg.BlockID),
+			Timestamp: ensureTime(msg.Timestamp),
+			Signature: decodeString(msg.Signature),
+		}
+		return &consensuspb.Message{Sum: &consensuspb.Message_Proposal{Proposal: &consensuspb.Proposal{Proposal: proposal}}}, nil
+	case "vote":
+		height, err := strconv.ParseInt(msg.Height, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vote height: %w", err)
+		}
+		round, err := strconv.ParseInt(msg.Round, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vote round: %w", err)
+		}
+		vote := &cmttypes.Vote{
+			Type:               cmttypes.SignedMsgType(msg.Type),
+			Height:             height,
+			Round:              int32(round),
+			Timestamp:          ensureTime(msg.Timestamp),
+			BlockID:            typesBlockIDFromAdapter(msg.BlockID),
+			ValidatorAddress:   decodeHexString(msg.ValidatorAddress),
+			ValidatorIndex:     msg.ValidatorIndex,
+			Signature:          decodeString(msg.Signature),
+			Extension:          decodeString(msg.Extension),
+			ExtensionSignature: decodeString(msg.ExtensionSignature),
+		}
+		return &consensuspb.Message{Sum: &consensuspb.Message_Vote{Vote: &consensuspb.Vote{Vote: vote}}}, nil
+	default:
+		return nil, errUnsupportedMessage
+	}
+}
+
+func typesBlockIDFromAdapter(block cometbftAdapter.BlockID) cmttypes.BlockID {
+	return cmttypes.BlockID{
+		Hash: hexDecodeOrCopy(block.Hash),
+		PartSetHeader: cmttypes.PartSetHeader{
+			Total: int(block.PartSetHeader.Total),
+			Hash:  append([]byte(nil), block.PartSetHeader.Hash...),
+		},
+	}
+}
+
+func encodeBase64(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+func decodeString(value string) []byte {
+	if value == "" {
+		return nil
+	}
+	if data, err := base64.StdEncoding.DecodeString(value); err == nil {
+		return data
+	}
+	return hexDecodeOrCopy(value)
+}
+
+func hexDecodeOrCopy(value string) []byte {
+	if value == "" {
+		return nil
+	}
+	if data, err := hex.DecodeString(strings.TrimPrefix(value, "0x")); err == nil {
+		return data
+	}
+	return []byte(value)
+}
+
+func decodeHexString(value string) []byte {
+	if value == "" {
+		return nil
+	}
+	if data, err := hex.DecodeString(strings.TrimPrefix(value, "0x")); err == nil {
+		return data
+	}
+	// addresses are expected to be hex, but fall back to raw bytes
+	return []byte(value)
+}
+
+func ensureTime(ts time.Time) time.Time {
+	if ts.IsZero() {
+		return time.Now().UTC()
+	}
+	return ts
+}
+
+func marshalConsensusMessage(msg *consensuspb.Message) ([]byte, error) {
+	return gogoproto.Marshal(msg)
+}

--- a/proxy/engine/engine.go
+++ b/proxy/engine/engine.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	p2pconn "github.com/cometbft/cometbft/p2p/conn"
+)
+
+// Engine runs the proxy.
+type Engine struct {
+	cfg     *Config
+	mapper  *cometbftAdapter.CometBFTMapper
+	metrics *Metrics
+}
+
+// New constructs a proxy engine from the configuration.
+func New(cfg *Config) *Engine {
+	if cfg == nil {
+		panic("engine config cannot be nil")
+	}
+	mapper := cometbftAdapter.NewCometBFTMapper(cfg.ChainID)
+	return &Engine{
+		cfg:     cfg,
+		mapper:  mapper,
+		metrics: NewMetrics(),
+	}
+}
+
+// Run starts accepting peers until the context is cancelled.
+func (e *Engine) Run(ctx context.Context) error {
+	ln, err := net.Listen(e.cfg.ListenNetwork, e.cfg.ListenAddress)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s://%s: %w", e.cfg.ListenNetwork, e.cfg.ListenAddress, err)
+	}
+	e.cfg.Logger.Info("proxy listening", "network", e.cfg.ListenNetwork, "address", e.cfg.ListenAddress)
+
+	var wg sync.WaitGroup
+	defer func() {
+		_ = ln.Close()
+		wg.Wait()
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				e.cfg.Logger.Warn("temporary accept error", "err", err)
+				continue
+			}
+			errCh <- err
+			break
+		}
+
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			if err := e.handleConnection(ctx, c); err != nil {
+				if ctx.Err() == nil {
+					e.cfg.Logger.Error("connection handler exited", "err", err, "remote", c.RemoteAddr().String())
+				}
+			}
+		}(conn)
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return ctx.Err()
+	}
+}
+
+func (e *Engine) handleConnection(ctx context.Context, downstreamConn net.Conn) error {
+	defer downstreamConn.Close()
+	remote := downstreamConn.RemoteAddr().String()
+	e.cfg.Logger.Info("accepted peer", "remote", remote)
+
+	downstreamSecret, err := p2pconn.MakeSecretConnection(downstreamConn, e.cfg.NodeKey.PrivKey)
+	if err != nil {
+		return fmt.Errorf("handshake with downstream peer failed: %w", err)
+	}
+
+	upstreamConn, err := net.DialTimeout(e.cfg.UpstreamNetwork, e.cfg.UpstreamAddress, e.cfg.DialTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to dial upstream %s://%s: %w", e.cfg.UpstreamNetwork, e.cfg.UpstreamAddress, err)
+	}
+
+	upstreamSecret, err := p2pconn.MakeSecretConnection(upstreamConn, e.cfg.NodeKey.PrivKey)
+	if err != nil {
+		upstreamConn.Close()
+		return fmt.Errorf("handshake with upstream failed: %w", err)
+	}
+
+	sessionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sess := newSession(sessionCtx, cancel, e.cfg, e.mapper, e.metrics, downstreamSecret, upstreamSecret)
+	if err := sess.run(); err != nil {
+		if !strings.Contains(err.Error(), "closed network connection") {
+			return err
+		}
+	}
+	return nil
+}

--- a/proxy/engine/engine_test.go
+++ b/proxy/engine/engine_test.go
@@ -1,0 +1,345 @@
+package engine
+
+import (
+	"context"
+	"encoding/hex"
+	"net"
+	"testing"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/p2p"
+	p2pconn "github.com/cometbft/cometbft/p2p/conn"
+	consensuspb "github.com/cometbft/cometbft/proto/tendermint/consensus"
+	cmttypes "github.com/cometbft/cometbft/types"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+)
+
+func TestSessionDoublePrevoteMutation(t *testing.T) {
+	nodeKey := &p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
+	height := int64(11)
+	trigger := Trigger{Height: &height, Step: "prevote"}
+
+	cfg, err := NewConfig(ConfigOptions{
+		ListenAddress:  "tcp://0.0.0.0:0",
+		UpstreamTarget: "tcp://0.0.0.0:0",
+		ChainID:        "test-chain",
+		NodeKey:        nodeKey,
+		Action:         cometbftAdapter.ByzantineActionDoubleVote,
+		Trigger:        trigger,
+		Hooks:          Hooks{},
+		Direction:      DirectionUpstream,
+		DialTimeout:    time.Second,
+	})
+	if err != nil {
+		t.Fatalf("config error: %v", err)
+	}
+
+	harness := newProxyHarness(t, cfg)
+	defer harness.Close()
+
+	voteBytes := make([]byte, 32)
+	for i := range voteBytes {
+		voteBytes[i] = 0xAA
+	}
+	vote := &cmttypes.Vote{
+		Type:             cmttypes.PrevoteType,
+		Height:           height,
+		Round:            2,
+		Timestamp:        time.Now().UTC(),
+		BlockID:          cmttypes.BlockID{Hash: voteBytes, PartSetHeader: cmttypes.PartSetHeader{Total: 1, Hash: []byte{0x01}}},
+		ValidatorAddress: []byte("validator-1"),
+		ValidatorIndex:   7,
+		Signature:        []byte("sig"),
+	}
+	payload := &consensuspb.Message{Sum: &consensuspb.Message_Vote{Vote: &consensuspb.Vote{Vote: vote}}}
+	raw, err := gogoproto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal vote: %v", err)
+	}
+
+	harness.sendUpstream(voteChannelID, raw)
+
+	msg1 := harness.mustReceive()
+	msg2 := harness.mustReceive()
+
+	vote1 := decodeVote(t, msg1)
+	vote2 := decodeVote(t, msg2)
+
+	hash1 := hex.EncodeToString(vote1.BlockID.Hash)
+	hash2 := hex.EncodeToString(vote2.BlockID.Hash)
+	original := hex.EncodeToString(vote.BlockID.Hash)
+
+	if hash1 == hash2 {
+		t.Fatalf("expected distinct hashes, got %s and %s", hash1, hash2)
+	}
+	if hash1 != original && hash2 != original {
+		t.Fatalf("expected one hash to match original %s, got %s and %s", original, hash1, hash2)
+	}
+	if hash1 == original {
+		ensureHashMutated(t, hash2, original)
+	} else {
+		ensureHashMutated(t, hash1, original)
+	}
+
+	harness.assertNoExtraMessages()
+}
+
+func TestSessionDropTriggeredMessage(t *testing.T) {
+	nodeKey := &p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
+	height := int64(5)
+	trigger := Trigger{Height: &height, Step: "prevote"}
+
+	cfg, err := NewConfig(ConfigOptions{
+		ListenAddress:  "tcp://0.0.0.0:0",
+		UpstreamTarget: "tcp://0.0.0.0:0",
+		ChainID:        "drop-chain",
+		NodeKey:        nodeKey,
+		Action:         cometbftAdapter.ByzantineActionNone,
+		Trigger:        trigger,
+		Hooks: Hooks{
+			Drop: true,
+		},
+		Direction:   DirectionUpstream,
+		DialTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("config error: %v", err)
+	}
+
+	harness := newProxyHarness(t, cfg)
+	defer harness.Close()
+
+	vote := &cmttypes.Vote{
+		Type:             cmttypes.PrevoteType,
+		Height:           height,
+		Round:            1,
+		Timestamp:        time.Now().UTC(),
+		BlockID:          cmttypes.BlockID{Hash: []byte{0x01}, PartSetHeader: cmttypes.PartSetHeader{Total: 1, Hash: []byte{0x02}}},
+		ValidatorAddress: []byte("validator"),
+		ValidatorIndex:   3,
+		Signature:        []byte("sig"),
+	}
+	payload := &consensuspb.Message{Sum: &consensuspb.Message_Vote{Vote: &consensuspb.Vote{Vote: vote}}}
+	raw, err := gogoproto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal vote: %v", err)
+	}
+
+	harness.sendUpstream(voteChannelID, raw)
+
+	select {
+	case <-harness.received:
+		t.Fatalf("expected message to be dropped")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestSessionDelayProposal(t *testing.T) {
+	nodeKey := &p2p.NodeKey{PrivKey: ed25519.GenPrivKey()}
+	height := int64(7)
+	trigger := Trigger{Height: &height, Step: "proposal"}
+	delay := 200 * time.Millisecond
+
+	cfg, err := NewConfig(ConfigOptions{
+		ListenAddress:  "tcp://0.0.0.0:0",
+		UpstreamTarget: "tcp://0.0.0.0:0",
+		ChainID:        "delay-chain",
+		NodeKey:        nodeKey,
+		Action:         cometbftAdapter.ByzantineActionNone,
+		Trigger:        trigger,
+		Hooks: Hooks{
+			Delay: delay,
+		},
+		Direction:   DirectionUpstream,
+		DialTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("config error: %v", err)
+	}
+
+	harness := newProxyHarness(t, cfg)
+	defer harness.Close()
+
+	proposal := &cmttypes.Proposal{
+		Type:      cmttypes.ProposalType,
+		Height:    height,
+		Round:     1,
+		POLRound:  0,
+		BlockID:   cmttypes.BlockID{Hash: []byte{0xAA}, PartSetHeader: cmttypes.PartSetHeader{Total: 1, Hash: []byte{0xBB}}},
+		Timestamp: time.Now().UTC(),
+		Signature: []byte("sig"),
+	}
+	payload := &consensuspb.Message{Sum: &consensuspb.Message_Proposal{Proposal: &consensuspb.Proposal{Proposal: proposal}}}
+	raw, err := gogoproto.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal proposal: %v", err)
+	}
+
+	start := time.Now()
+	harness.sendUpstream(dataChannelID, raw)
+
+	<-harness.received
+	elapsed := time.Since(start)
+	if elapsed < delay {
+		t.Fatalf("expected delay of at least %v, got %v", delay, elapsed)
+	}
+}
+
+// proxyHarness manages a session and associated peer connections for tests.
+type proxyHarness struct {
+	t       *testing.T
+	cfg     *Config
+	mapper  *cometbftAdapter.CometBFTMapper
+	metrics *Metrics
+	ctx     context.Context
+	cancel  context.CancelFunc
+	session *session
+	errCh   chan error
+
+	upstreamPeer   *p2pconn.MConnection
+	downstreamPeer *p2pconn.MConnection
+
+	upstreamSecret   *p2pconn.SecretConnection
+	downstreamSecret *p2pconn.SecretConnection
+
+	received chan []byte
+}
+
+func newProxyHarness(t *testing.T, cfg *Config) *proxyHarness {
+	t.Helper()
+
+	mapper := cometbftAdapter.NewCometBFTMapper(cfg.ChainID)
+	metrics := NewMetrics()
+
+	localPriv, ok := cfg.NodeKey.PrivKey.(ed25519.PrivKey)
+	if !ok {
+		t.Fatalf("unexpected private key type %T", cfg.NodeKey.PrivKey)
+	}
+
+	downstreamSecret, downstreamPeer := makeSecretConnPair(t, localPriv, ed25519.GenPrivKey())
+	upstreamSecret, upstreamPeer := makeSecretConnPair(t, localPriv, ed25519.GenPrivKey())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sess := newSession(ctx, cancel, cfg, mapper, metrics, downstreamSecret, upstreamSecret)
+
+	received := make(chan []byte, 10)
+
+	downRecv := func(chID byte, msg []byte) {
+		if chID == stateChannelID || chID == dataChannelID || chID == voteChannelID || chID == voteSetBitsChannelID {
+			received <- append([]byte(nil), msg...)
+		}
+	}
+	upRecv := func(chID byte, msg []byte) {}
+
+	downstreamPeerConn := p2pconn.NewMConnection(downstreamPeer, defaultDescriptors(), downRecv, func(any) {})
+	upstreamPeerConn := p2pconn.NewMConnection(upstreamPeer, defaultDescriptors(), upRecv, func(any) {})
+
+	if err := downstreamPeerConn.Start(); err != nil {
+		t.Fatalf("downstream peer start: %v", err)
+	}
+	if err := upstreamPeerConn.Start(); err != nil {
+		t.Fatalf("upstream peer start: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sess.run()
+	}()
+
+	return &proxyHarness{
+		t:                t,
+		cfg:              cfg,
+		mapper:           mapper,
+		metrics:          metrics,
+		ctx:              ctx,
+		cancel:           cancel,
+		session:          sess,
+		errCh:            errCh,
+		upstreamPeer:     upstreamPeerConn,
+		downstreamPeer:   downstreamPeerConn,
+		upstreamSecret:   upstreamSecret,
+		downstreamSecret: downstreamSecret,
+		received:         received,
+	}
+}
+
+func (h *proxyHarness) sendUpstream(chID byte, payload []byte) {
+	if ok := h.upstreamPeer.Send(chID, payload); !ok {
+		h.t.Fatalf("failed to send upstream payload")
+	}
+}
+
+func (h *proxyHarness) mustReceive() []byte {
+	select {
+	case msg := <-h.received:
+		return msg
+	case <-time.After(2 * time.Second):
+		h.t.Fatalf("timed out waiting for message")
+		return nil
+	}
+}
+
+func (h *proxyHarness) assertNoExtraMessages() {
+	select {
+	case msg := <-h.received:
+		h.t.Fatalf("unexpected extra message: %x", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func (h *proxyHarness) Close() {
+	h.cancel()
+	<-h.errCh
+	h.upstreamPeer.FlushStop()
+	h.downstreamPeer.FlushStop()
+	h.upstreamSecret.Close()
+	h.downstreamSecret.Close()
+}
+
+func decodeVote(t *testing.T, payload []byte) *cmttypes.Vote {
+	t.Helper()
+	var msg consensuspb.Message
+	if err := msg.Unmarshal(payload); err != nil {
+		t.Fatalf("decode vote: %v", err)
+	}
+	if msg.GetVote() == nil || msg.GetVote().GetVote() == nil {
+		t.Fatalf("expected vote message")
+	}
+	return msg.GetVote().GetVote()
+}
+
+func ensureHashMutated(t *testing.T, got, original string) {
+	t.Helper()
+	if got == original {
+		t.Fatalf("expected mutated hash different from original %s", original)
+	}
+}
+
+func makeSecretConnPair(t *testing.T, localKey, remoteKey ed25519.PrivKey) (*p2pconn.SecretConnection, *p2pconn.SecretConnection) {
+	t.Helper()
+	a, b := net.Pipe()
+	remoteCh := make(chan *p2pconn.SecretConnection, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		conn, err := p2pconn.MakeSecretConnection(b, remoteKey)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		remoteCh <- conn
+		errCh <- nil
+	}()
+
+	localConn, err := p2pconn.MakeSecretConnection(a, localKey)
+	if err != nil {
+		t.Fatalf("local secret connection: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("remote secret connection: %v", err)
+	}
+	return localConn, <-remoteCh
+}

--- a/proxy/engine/metrics.go
+++ b/proxy/engine/metrics.go
@@ -1,0 +1,53 @@
+package engine
+
+import "sync/atomic"
+
+// Metrics tracks runtime counters for the proxy.
+type Metrics struct {
+	mutated    atomic.Int64
+	dropped    atomic.Int64
+	duplicated atomic.Int64
+	delayed    atomic.Int64
+}
+
+// NewMetrics creates an empty metrics handle.
+func NewMetrics() *Metrics {
+	return &Metrics{}
+}
+
+func (m *Metrics) IncMutated(delta int64) {
+	if m != nil && delta != 0 {
+		m.mutated.Add(delta)
+	}
+}
+
+func (m *Metrics) IncDropped() {
+	if m != nil {
+		m.dropped.Add(1)
+	}
+}
+
+func (m *Metrics) IncDuplicated(count int) {
+	if m != nil && count > 0 {
+		m.duplicated.Add(int64(count))
+	}
+}
+
+func (m *Metrics) IncDelayed() {
+	if m != nil {
+		m.delayed.Add(1)
+	}
+}
+
+// Snapshot returns the current counter values.
+func (m *Metrics) Snapshot() map[string]int64 {
+	if m == nil {
+		return nil
+	}
+	return map[string]int64{
+		"mutated":    m.mutated.Load(),
+		"dropped":    m.dropped.Load(),
+		"duplicated": m.duplicated.Load(),
+		"delayed":    m.delayed.Load(),
+	}
+}

--- a/proxy/engine/session.go
+++ b/proxy/engine/session.go
@@ -1,0 +1,264 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	cometbftAdapter "codec/cometbft/adapter"
+	"codec/message/abstraction"
+	p2pconn "github.com/cometbft/cometbft/p2p/conn"
+	consensuspb "github.com/cometbft/cometbft/proto/tendermint/consensus"
+	evidpb "github.com/cometbft/cometbft/proto/tendermint/evidence"
+	mempoolpb "github.com/cometbft/cometbft/proto/tendermint/mempool"
+)
+
+const (
+	mempoolChannelID  byte = 0x30
+	evidenceChannelID byte = 0x38
+)
+
+type session struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	cfg     *Config
+	mapper  *cometbftAdapter.CometBFTMapper
+	metrics *Metrics
+
+	downstream *p2pconn.MConnection
+	upstream   *p2pconn.MConnection
+
+	logger  *slog.Logger
+	errOnce sync.Once
+	err     error
+}
+
+func newSession(ctx context.Context, cancel context.CancelFunc, cfg *Config, mapper *cometbftAdapter.CometBFTMapper, metrics *Metrics, downstream, upstream net.Conn) *session {
+	s := &session{
+		ctx:     ctx,
+		cancel:  cancel,
+		cfg:     cfg,
+		mapper:  mapper,
+		metrics: metrics,
+		logger:  cfg.Logger.With("remote", downstream.RemoteAddr().String()),
+	}
+
+	downRecv := func(chID byte, payload []byte) {
+		s.handleDownstream(chID, payload)
+	}
+	upRecv := func(chID byte, payload []byte) {
+		s.handleUpstream(chID, payload)
+	}
+	onError := func(direction flowDirection) func(any) {
+		return func(err any) {
+			s.recordError(fmt.Errorf("%s mconnection error: %v", direction, err))
+		}
+	}
+
+	s.downstream = p2pconn.NewMConnection(downstream, defaultDescriptors(), downRecv, onError(directionDownstream))
+	s.upstream = p2pconn.NewMConnection(upstream, defaultDescriptors(), upRecv, onError(directionUpstream))
+
+	return s
+}
+
+func (s *session) run() error {
+	if err := s.downstream.Start(); err != nil {
+		s.recordError(err)
+		return err
+	}
+	if err := s.upstream.Start(); err != nil {
+		s.downstream.Stop()
+		s.recordError(err)
+		return err
+	}
+
+	defer s.downstream.FlushStop()
+	defer s.upstream.FlushStop()
+
+	<-s.ctx.Done()
+	if s.err != nil {
+		return s.err
+	}
+	return s.ctx.Err()
+}
+
+func (s *session) handleDownstream(chID byte, payload []byte) {
+	if s.cfg.Direction.ShouldMutateDownstream() && isConsensusChannel(chID) {
+		if err := s.processConsensus(directionDownstream, chID, payload, s.upstream); err != nil {
+			s.logger.Warn("failed to process downstream consensus message", "err", err)
+			s.forwardRaw(s.upstream, chID, payload)
+		}
+		return
+	}
+	s.forwardRaw(s.upstream, chID, payload)
+}
+
+func (s *session) handleUpstream(chID byte, payload []byte) {
+	if s.cfg.Direction.ShouldMutateUpstream() && isConsensusChannel(chID) {
+		if err := s.processConsensus(directionUpstream, chID, payload, s.downstream); err != nil {
+			s.logger.Warn("failed to process upstream consensus message", "err", err)
+			s.forwardRaw(s.downstream, chID, payload)
+		}
+		return
+	}
+	s.forwardRaw(s.downstream, chID, payload)
+}
+
+func (s *session) processConsensus(direction flowDirection, chID byte, payload []byte, target *p2pconn.MConnection) error {
+	msg, err := decodeConsensusMessage(payload)
+	if err != nil {
+		return err
+	}
+
+	canonical, err := canonicalFromConsensus(s.mapper, s.cfg.ChainID, msg)
+	if err != nil {
+		if errors.Is(err, errUnsupportedMessage) {
+			s.forwardRaw(target, chID, payload)
+			return nil
+		}
+		return err
+	}
+
+	if !s.cfg.Trigger.Matches(canonical) {
+		s.forwardRaw(target, chID, payload)
+		return nil
+	}
+
+	if s.cfg.Hooks.Delay > 0 {
+		s.metrics.IncDelayed()
+		time.Sleep(s.cfg.Hooks.Delay)
+	}
+
+	if s.cfg.Hooks.Drop {
+		s.metrics.IncDropped()
+		s.logger.Info("dropped consensus message", "direction", direction, "channel", fmt.Sprintf("0x%X", chID), "height", canonicalHeight(canonical), "round", canonicalRound(canonical), "type", canonical.Type)
+		return nil
+	}
+
+	raws, err := s.applyByzantineAction(canonical)
+	if err != nil {
+		return err
+	}
+
+	sent := 0
+	duplicateCount := 0
+	for _, raw := range raws {
+		protoMsg, err := rawToConsensusMessage(raw)
+		if err != nil {
+			return err
+		}
+		bytes, err := marshalConsensusMessage(protoMsg)
+		if err != nil {
+			return err
+		}
+		s.forwardRaw(target, chID, bytes)
+		sent++
+		if s.cfg.Hooks.Duplicate {
+			s.forwardRaw(target, chID, bytes)
+			sent++
+			duplicateCount++
+		}
+	}
+
+	s.metrics.IncMutated(int64(sent))
+	if duplicateCount > 0 {
+		s.metrics.IncDuplicated(duplicateCount)
+	}
+
+	s.logger.Info("mutated consensus message", "direction", direction, "channel", fmt.Sprintf("0x%X", chID), "height", canonicalHeight(canonical), "round", canonicalRound(canonical), "type", canonical.Type, "count", sent, "duplicates", duplicateCount)
+
+	return nil
+}
+
+func (s *session) applyByzantineAction(canonical *abstraction.CanonicalMessage) ([]*abstraction.RawConsensusMessage, error) {
+	if s.cfg.Action == cometbftAdapter.ByzantineActionNone {
+		raw, err := s.mapper.FromCanonical(canonical)
+		if err != nil {
+			return nil, err
+		}
+		return []*abstraction.RawConsensusMessage{raw}, nil
+	}
+	return s.mapper.FromCanonicalByzantine(canonical, s.cfg.Action, s.cfg.Options)
+}
+
+func (s *session) forwardRaw(target *p2pconn.MConnection, chID byte, payload []byte) {
+	if ok := target.Send(chID, append([]byte(nil), payload...)); !ok {
+		s.logger.Warn("failed to forward message", "channel", fmt.Sprintf("0x%X", chID))
+	}
+}
+
+func (s *session) recordError(err error) {
+	if err == nil {
+		return
+	}
+	s.errOnce.Do(func() {
+		s.err = err
+		s.cancel()
+	})
+}
+
+func canonicalHeight(msg *abstraction.CanonicalMessage) int64 {
+	if msg == nil || msg.Height == nil {
+		return 0
+	}
+	return msg.Height.Int64()
+}
+
+func canonicalRound(msg *abstraction.CanonicalMessage) int64 {
+	if msg == nil || msg.Round == nil {
+		return 0
+	}
+	return msg.Round.Int64()
+}
+
+func defaultDescriptors() []*p2pconn.ChannelDescriptor {
+	return []*p2pconn.ChannelDescriptor{
+		{
+			ID:                  stateChannelID,
+			Priority:            6,
+			SendQueueCapacity:   100,
+			RecvMessageCapacity: 1 << 20,
+			MessageType:         &consensuspb.Message{},
+		},
+		{
+			ID:                  dataChannelID,
+			Priority:            10,
+			SendQueueCapacity:   100,
+			RecvMessageCapacity: 1 << 20,
+			MessageType:         &consensuspb.Message{},
+		},
+		{
+			ID:                  voteChannelID,
+			Priority:            7,
+			SendQueueCapacity:   100,
+			RecvMessageCapacity: 1 << 20,
+			MessageType:         &consensuspb.Message{},
+		},
+		{
+			ID:                  voteSetBitsChannelID,
+			Priority:            1,
+			SendQueueCapacity:   10,
+			RecvMessageCapacity: 1 << 20,
+			MessageType:         &consensuspb.Message{},
+		},
+		{
+			ID:                  mempoolChannelID,
+			Priority:            5,
+			SendQueueCapacity:   128,
+			RecvMessageCapacity: 1 << 21,
+			MessageType:         &mempoolpb.Message{},
+		},
+		{
+			ID:                  evidenceChannelID,
+			Priority:            4,
+			SendQueueCapacity:   32,
+			RecvMessageCapacity: 1 << 20,
+			MessageType:         &evidpb.Message{},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add a `byzproxy` CLI that wires together listen/upstream flags, node key loading, byzantine actions, triggers, and hooks
- introduce a `proxy/engine` package with configuration, consensus message conversion, secret-connection bridging, mutation hooks, structured logging, and metrics
- exercise the proxy with net.Pipe-based tests covering double prevote, drop, and delayed proposal scenarios
- pin the CometBFT replace to the vendored tree and align the secp256k1 dependency

## Testing
- go test ./... *(fails: required CometBFT dependencies cannot be downloaded in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffddf03c8c832b81fed940d1d4d138